### PR TITLE
release(lwndev-sdlc): v1.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.5.0"
+      "version": "1.5.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.5.1] - 2026-03-30
+
+### Bug Fixes
+
+- **stop-hooks:** replace prompt-based Stop hooks with command-based hooks in `documenting-qa`, `executing-qa`, and `releasing-plugins` to eliminate intermittent JSON validation failures ([#114](https://github.com/lwndev/lwndev-marketplace/issues/114))
+- **stop-hooks:** use `${CLAUDE_PLUGIN_ROOT}` for command hook paths in plugin skills
+- **stop-hooks:** fix Phase 1/2 detection order in releasing-plugins stop hook
+
+[1.5.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.5.0...lwndev-sdlc@1.5.1
+
 ## [1.5.0] - 2026-03-30
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.5.0 | **Released:** 2026-03-30
+**Version:** 1.5.1 | **Released:** 2026-03-30
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release for `lwndev-sdlc` plugin (v1.5.0 → v1.5.1).

### Bug Fixes

- **stop-hooks:** Replace prompt-based Stop hooks with command-based hooks in `documenting-qa`, `executing-qa`, and `releasing-plugins` to eliminate intermittent JSON validation failures (#114)
- **stop-hooks:** Use `${CLAUDE_PLUGIN_ROOT}` for command hook paths in plugin skills
- **stop-hooks:** Fix Phase 1/2 detection order in releasing-plugins stop hook

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)