### PR TITLE
release(lwndev-sdlc): v1.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.5.1"
+      "version": "1.6.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.6.0] - 2026-04-05
+
+### Features
+
+- **managing-work-items:** new skill centralizing all issue tracker operations (fetch, comment) with automatic backend detection (`#N` → GitHub Issues, `PROJ-123` → Jira) ([#119](https://github.com/lwndev/lwndev-marketplace/issues/119))
+- **managing-work-items:** Jira support via tiered fallback — Rovo MCP (primary), Atlassian CLI (fallback), skip (graceful degradation)
+- **managing-work-items:** Jira comment templates in Atlassian Document Format (ADF) JSON for Rovo MCP compatibility
+- **managing-work-items:** consolidated GitHub issue comment templates from three execution skills into single source of truth
+- **orchestrating-workflows:** integrated `managing-work-items` invocation points across feature, chore, and bug chains
+- **documenting-features:** delegated issue fetch to `managing-work-items` skill
+- **implementing-plan-phases:** removed inline `gh issue` operations; issue tracking delegated to orchestrator
+- **executing-chores:** removed inline `gh issue` operations; issue tracking delegated to orchestrator
+- **executing-bug-fixes:** removed inline `gh issue` operations; issue tracking delegated to orchestrator
+
+[1.6.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.5.1...lwndev-sdlc@1.6.0
+
 ## [1.5.1] - 2026-03-30
 
 ### Bug Fixes

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.5.1 | **Released:** 2026-03-30
+**Version:** 1.6.0 | **Released:** 2026-04-05
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

- Bump lwndev-sdlc plugin from v1.5.1 to v1.6.0
- New `managing-work-items` skill centralizing issue tracker operations (GitHub Issues + Jira)
- Refactored 4 existing skills to delegate issue tracking to orchestrator
- Updated orchestrator with `managing-work-items` invocation points across all workflow chains

## Changelog

See `plugins/lwndev-sdlc/CHANGELOG.md` for the full entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)