### PR TITLE
release(lwndev-sdlc): v1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.6.0"
+      "version": "1.7.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.7.0] - 2026-04-07
+
+### Features
+
+- **stop-hook:** replace keyword-based pattern exclusion with state-file scoping in releasing-plugins stop hook — uses `.sdlc/releasing/.active` and `.phase1-complete` marker files to eliminate false positives ([#125](https://github.com/lwndev/lwndev-marketplace/issues/125))
+
+### Bug Fixes
+
+- **stop-hook:** skip release validation for non-release messages (BUG-008) ([#124](https://github.com/lwndev/lwndev-marketplace/pull/124))
+
+[1.7.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.6.0...lwndev-sdlc@1.7.0
+
 ## [1.6.0] - 2026-04-05
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.6.0 | **Released:** 2026-04-05
+**Version:** 1.7.0 | **Released:** 2026-04-07
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

- **stop-hook:** Replace keyword-based pattern exclusion with state-file scoping using `.sdlc/releasing/.active` and `.phase1-complete` marker files (FEAT-013, #125)
- **stop-hook:** Skip release validation for non-release messages (BUG-008, #124)

## Version

`1.6.0` → `1.7.0` (minor)

## Files Changed

- `plugins/lwndev-sdlc/.claude-plugin/plugin.json` — version bump
- `.claude-plugin/marketplace.json` — version bump
- `plugins/lwndev-sdlc/CHANGELOG.md` — new release section
- `plugins/lwndev-sdlc/README.md` — version + date update