### PR TITLE
release(lwndev-sdlc): v1.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.8.0"
+      "version": "1.8.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## [1.8.1] - Unreleased
+## [1.8.1] - 2026-04-12
 
 ### Bug Fixes
 
 - **orchestrating-workflows:** define the `managing-work-items` invocation mechanism so the v1.7.0 integration actually runs (BUG-009) ([#131](https://github.com/lwndev/lwndev-marketplace/issues/131)). Previously the orchestrator silently skipped all 11 `managing-work-items` call sites (4 operations: `fetch`, `extract-ref`, `comment`, `pr-link`) because `orchestrating-workflows/SKILL.md` prescribed the calls but never specified *how* to invoke them, and the Forked Steps recipe explicitly scoped itself to chain-table steps. The orchestrator now reads `managing-work-items/SKILL.md` once at workflow start and executes the documented `gh` / `acli` / Rovo MCP commands **inline from its main context** — no Agent-tool fork, no Skill-tool call. A new "How to Invoke `managing-work-items`" subsection documents the mechanism with runnable examples for all four operations, the Forked Steps section now explicitly excludes cross-cutting skills, `managing-work-items/SKILL.md:25` no longer carries the misleading "not directly by users" framing, mechanism-missing failures emit WARNING-level log lines distinguishable from the legitimate INFO-level empty-`issueRef` skip, and a new "Issue Tracking Verification" checklist distinguishes invocation-succeeded from gracefully-skipped from mechanism-failed states. Users should now see `phase-start` / `phase-completion` / `work-start` / `work-complete` / `bug-start` / `bug-complete` comments appear on linked GitHub issues (and Jira issues where a backend is available) on future workflows.
+
+[1.8.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.8.0...lwndev-sdlc@1.8.1
 
 ## [1.8.0] - 2026-04-11
 

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.8.0 | **Released:** 2026-04-11
+**Version:** 1.8.1 | **Released:** 2026-04-12
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release of `lwndev-sdlc` bumping 1.8.0 → 1.8.1.

- **BUG-009 fix**: `orchestrating-workflows` now defines the `managing-work-items` invocation mechanism (inline execution from the orchestrator's main context), so the v1.7.0 integration finally runs instead of silently skipping every call site. Fixes #131.
- **Post-review cleanup**: replaced a `<<'EOF'` heredoc example with the canonical plain double-quoted string form to prevent broken copy-paste from raw markdown.

## Test plan

- [x] `npm run validate` — 13/13 plugin skills
- [x] `npm test` — 701/701
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Dogfood verification: issue #131 now carries `bug-start` and `bug-complete` comments posted inline from the orchestrator's main context (previously would have been silently skipped)
- [ ] Post-merge: `npm run release:tag -- --plugin lwndev-sdlc` to create the `lwndev-sdlc@1.8.1` tag

Closes #131 (via #134 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)