### PR TITLE
chore(refactoring): tighten bug classifier and skip unnecessary fork steps

### DIFF
--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -219,7 +219,7 @@ The chore chain has a fixed 9 steps with no phase loop and no plan-approval paus
 | 1 | Document chore | `documenting-chores` | **main** |
 | 2 | Review requirements (standard) | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 3 | Document QA test plan | `documenting-qa` | **main** |
-| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low` or no mapping sections) |
+| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 5 | Execute chore | `executing-chores` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
 | 7 | Reconcile post-review | `reviewing-requirements` | fork |
@@ -235,7 +235,7 @@ The bug chain has a fixed 9 steps with no phase loop and no plan-approval pause,
 | 1 | Document bug | `documenting-bugs` | **main** |
 | 2 | Review requirements (standard) | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 3 | Document QA test plan | `documenting-qa` | **main** |
-| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low` or no mapping sections) |
+| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 5 | Execute bug fix | `executing-bug-fixes` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
 | 7 | Reconcile post-review | `reviewing-requirements` | fork |
@@ -632,7 +632,7 @@ If the plan file is missing or malformed, `classify-post-plan` retains the init-
 
 ### Chore Chain Step-Specific Fork Instructions
 
-Steps 2, 4, 7, and 9 follow the same fork pattern as the feature chain without chore-specific overrides. Every fork runs the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-14 echo) with the appropriate step-name and mode before spawning the subagent, and passes the resolved tier as the Agent tool's `model` parameter:
+Steps 2, 4, 7, and 9 follow the same fork pattern as the feature chain without chore-specific overrides. Every non-skipped fork runs the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-14 echo) with the appropriate step-name and mode before spawning the subagent, and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
 
 **Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
@@ -640,7 +640,7 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
 ```
 Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
 
-**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, or the produced `qa/test-plans/QA-plan-{ID}.md` contains no mapping sections (grep for lines matching `^##+ .*[Mm]apping` returns no results), skip this fork — advance state without spawning a subagent:
+**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
 ```
@@ -683,7 +683,7 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-r
 
 ### Bug Chain Step-Specific Fork Instructions
 
-Steps 2, 4, 7, and 9 follow the same fork pattern as the chore chain. Every fork runs the FEAT-014 pre-fork sequence before spawning the subagent and passes the resolved tier as the Agent tool's `model` parameter:
+Steps 2, 4, 7, and 9 follow the same fork pattern as the chore chain. Every non-skipped fork runs the FEAT-014 pre-fork sequence before spawning the subagent and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
 
 **Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
@@ -691,7 +691,7 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
 ```
 Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
 
-**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, or the produced `qa/test-plans/QA-plan-{ID}.md` contains no mapping sections (grep for lines matching `^##+ .*[Mm]apping` returns no results), skip this fork — advance state without spawning a subagent:
+**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
 ```
@@ -989,7 +989,7 @@ Before marking the workflow complete:
 - [ ] State file at `.sdlc/workflows/{ID}.json` reflects completion
 - [ ] Artifacts exist for all completed steps
 - [ ] Sub-skills were NOT modified — no `context: fork` added to their frontmatter
-- [ ] Reconciliation steps (reviewing-requirements in test-plan and code-review modes) were not skipped
+- [ ] Reconciliation steps (reviewing-requirements in test-plan and code-review modes) were not skipped — unless CHORE-031 skip conditions apply (bug/chore chains: step 2 skipped if `complexity == low`; step 4 skipped if `complexity == low`)
 - [ ] Stop hook prevents premature stopping during in-progress steps
 
 ### Feature Chain Checks

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -217,9 +217,9 @@ The chore chain has a fixed 9 steps with no phase loop and no plan-approval paus
 | # | Step | Skill | Context |
 |---|------|-------|---------|
 | 1 | Document chore | `documenting-chores` | **main** |
-| 2 | Review requirements (standard) | `reviewing-requirements` | fork |
+| 2 | Review requirements (standard) | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 3 | Document QA test plan | `documenting-qa` | **main** |
-| 4 | Reconcile test plan | `reviewing-requirements` | fork |
+| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low` or no mapping sections) |
 | 5 | Execute chore | `executing-chores` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
 | 7 | Reconcile post-review | `reviewing-requirements` | fork |
@@ -233,9 +233,9 @@ The bug chain has a fixed 9 steps with no phase loop and no plan-approval pause,
 | # | Step | Skill | Context |
 |---|------|-------|---------|
 | 1 | Document bug | `documenting-bugs` | **main** |
-| 2 | Review requirements (standard) | `reviewing-requirements` | fork |
+| 2 | Review requirements (standard) | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 3 | Document QA test plan | `documenting-qa` | **main** |
-| 4 | Reconcile test plan | `reviewing-requirements` | fork |
+| 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low` or no mapping sections) |
 | 5 | Execute bug fix | `executing-bug-fixes` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
 | 7 | Reconcile post-review | `reviewing-requirements` | fork |
@@ -634,9 +634,17 @@ If the plan file is missing or malformed, `classify-post-plan` retains the init-
 
 Steps 2, 4, 7, and 9 follow the same fork pattern as the feature chain without chore-specific overrides. Every fork runs the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-14 echo) with the appropriate step-name and mode before spawning the subagent, and passes the resolved tier as the Agent tool's `model` parameter:
 
-**Step 2 — `reviewing-requirements` (standard review)**: Append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
+**Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
+```
+Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
 
-**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: Append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `test-plan`.
+**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, or the produced `qa/test-plans/QA-plan-{ID}.md` contains no mapping sections (grep for lines matching `^##+ .*[Mm]apping` returns no results), skip this fork — advance state without spawning a subagent:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
+```
+Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `test-plan`.
 
 **Step 5 — `executing-chores` (fork)**:
 
@@ -677,9 +685,17 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-r
 
 Steps 2, 4, 7, and 9 follow the same fork pattern as the chore chain. Every fork runs the FEAT-014 pre-fork sequence before spawning the subagent and passes the resolved tier as the Agent tool's `model` parameter:
 
-**Step 2 — `reviewing-requirements` (standard review)**: Append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
+**Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
+```
+Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `standard`.
 
-**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: Append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `test-plan`.
+**Step 4 — `reviewing-requirements` (test-plan reconciliation)**: **Skip condition (CHORE-031 T6)**: if `complexity == low`, or the produced `qa/test-plans/QA-plan-{ID}.md` contains no mapping sections (grep for lines matching `^##+ .*[Mm]apping` returns no results), skip this fork — advance state without spawning a subagent:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID}
+```
+Otherwise, append `{ID}` as argument. Pre-fork step-name `reviewing-requirements`, mode `test-plan`.
 
 **Step 5 — `executing-bug-fixes` (fork)**:
 

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -520,11 +520,24 @@ _classify_bug() {
   fi
 
   # Category bump (security or performance → bump one tier).
+  local cat_bump=false
   case "$category" in
     security|performance)
       base=$(_bump_complexity "$base")
+      cat_bump=true
       ;;
   esac
+
+  # CHORE-031 / T1: neither severity alone nor RC count alone can promote
+  # to high. Require severity ≥ medium AND at least one escalation signal
+  # (rc_count ≥ 4 → rc_tier=high, or security/performance category bump).
+  if [[ "$base" == "high" ]]; then
+    local sev_rank=0
+    case "$sev_tier" in medium) sev_rank=2 ;; high) sev_rank=3 ;; esac
+    if (( sev_rank < 2 )) || { [[ "$rc_tier" != "high" ]] && [[ "$cat_bump" != "true" ]]; }; then
+      base="medium"
+    fi
+  fi
 
   echo "$base"
 }

--- a/qa/test-plans/QA-plan-CHORE-031.md
+++ b/qa/test-plans/QA-plan-CHORE-031.md
@@ -1,0 +1,86 @@
+# QA Test Plan: Tighten Bug Classifier and Skip Unnecessary Fork Steps
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Plan ID** | QA-plan-CHORE-031 |
+| **Requirement Type** | CHORE |
+| **Requirement ID** | CHORE-031 |
+| **Source Documents** | `requirements/chores/CHORE-031-tighten-classifier-skip-steps.md` |
+| **Date Created** | 2026-04-12 |
+
+## Existing Test Verification
+
+Tests that already exist and must continue to pass (regression baseline):
+
+| Test File | Description | Status |
+|-----------|-------------|--------|
+| `scripts/__tests__/workflow-state.test.ts` — `bug classifier` suite | 7 tests covering `_classify_bug` across severity/RC/category combinations | PASS |
+| `scripts/__tests__/orchestrating-workflows.test.ts` — `${CLAUDE_SKILL_DIR}` ref count | Asserts all `workflow-state.sh` references use the prefixed form (count = 66) | PASS |
+| `scripts/__tests__/orchestrating-workflows.test.ts` — chore chain lifecycle | Full 9-step chore chain init → advance → pause → resume → complete | PASS |
+| `scripts/__tests__/orchestrating-workflows.test.ts` — bug chain lifecycle | Full 9-step bug chain init → advance → pause → resume → complete | PASS |
+| `scripts/__tests__/orchestrating-workflows.test.ts` — FEAT-014 adaptive model selection | Examples A, B, C verifying tier resolution across chain types | PASS |
+| `scripts/__tests__/workflow-state.test.ts` — feature init classifier | 6 tests ensuring feature classifier is unaffected | PASS |
+| `scripts/__tests__/workflow-state.test.ts` — chore classifier | 6 tests ensuring chore classifier is unaffected | PASS |
+
+## New Test Analysis
+
+New or modified tests that should be created or verified during QA execution:
+
+| Test Description | Target File(s) | Requirement Ref | Priority | Status |
+|-----------------|----------------|-----------------|----------|--------|
+| Critical severity alone caps at medium | `workflow-state.test.ts` — `bug-critical-severity.md` fixture | AC-1 | High | PASS |
+| RC count 4 alone caps at medium when severity is low | `workflow-state.test.ts` — `bug-max-severity-rc.md` fixture | AC-1 | High | PASS |
+| High severity + 4 RCs + logic-error → high via rc_tier branch | `workflow-state.test.ts` — `bug-high-rc-only.md` fixture | AC-1, AC-2 | High | PASS |
+| High severity + 3 RCs + security category → high (unchanged) | `workflow-state.test.ts` — `bug-high.md` fixture | AC-5 | Medium | PASS |
+| `${CLAUDE_SKILL_DIR}` reference count updated to 66 | `orchestrating-workflows.test.ts` line 70 | AC-3, AC-4 | Medium | PASS |
+
+## Coverage Gap Analysis
+
+Code paths and functionality that lack test coverage:
+
+| Gap Description | Affected Code | Requirement Ref | Recommendation |
+|----------------|---------------|-----------------|----------------|
+| No automated test for step 2/4 skip behavior at runtime | `SKILL.md` step 2/4 skip conditions (prose instructions) | AC-3, AC-4 | Manual verify: inspect SKILL.md prose for correct skip conditions and `advance` calls |
+| No automated test for `severity=medium + rc_count>=4 + logic-error` | `workflow-state.sh:_classify_bug` | AC-1 | Manual verify: trace through logic to confirm this returns `high` |
+| Feature chain step tables have no skip annotations | `SKILL.md` feature chain step sequence | AC-5 | Manual verify: confirm feature chain tables at lines 198-211 are untouched |
+
+## Code Path Verification
+
+Traceability from acceptance criteria to implementation:
+
+| Requirement | Description | Expected Code Path | Verification Method | Status |
+|-------------|-------------|-------------------|-------------------|--------|
+| AC-1 | `_classify_bug` no longer returns `high` from severity alone or RC count alone | `workflow-state.sh:531-540` — T1 guard caps `base` at `medium` when `sev_rank < 2` or no escalation signal | Automated: 3 tests (`bug-critical-severity`, `bug-max-severity-rc`, `bug-high-rc-only`) | PASS |
+| AC-2 | A BUG-009-equivalent bug resolves to `sonnet` | `workflow-state.sh:534-539` — severity=high + 1 RC + documentation → `sev_rank=3` but `rc_tier != "high"` and `cat_bump != "true"` → capped to `medium` (sonnet) | Automated: `bug-critical-severity` test (severity=critical, 1 RC, logic-error → medium) | PASS |
+| AC-3 | Bug/chore chains with `complexity == low` skip step 2 | `SKILL.md:637-641` (chore) and `SKILL.md:688-692` (bug) — skip condition reads complexity from state file, calls `advance` if low | Manual: inspect SKILL.md prose, confirm `advance` call, confirm step tables annotated | PASS |
+| AC-4 | Test-plan reconciliation fork skipped when `complexity == low` | `SKILL.md:643-647` (chore) and `SKILL.md:694-698` (bug) — skip condition gates on `complexity == low` only | Manual: inspect SKILL.md prose, confirm `advance` call, confirm step tables annotated | PASS |
+| AC-5 | Feature-chain behavior unchanged | Feature chain step table (`SKILL.md:198-211`), feature chain fork instructions (`SKILL.md:607-632`) | Manual: confirm no CHORE-031 annotations in feature chain sections; automated: feature classifier tests unchanged | PASS |
+
+## Deliverable Verification
+
+| Deliverable | Source | Expected Path | Status |
+|-------------|--------|---------------|--------|
+| Refactored `_classify_bug` with T1 guard | T1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh:531-540` | PASS |
+| Step 2 skip condition in chore chain fork instructions | T2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:637-641` | PASS |
+| Step 2 skip condition in bug chain fork instructions | T2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:688-692` | PASS |
+| Step 4 skip condition in chore chain fork instructions | T6 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:643-647` | PASS |
+| Step 4 skip condition in bug chain fork instructions | T6 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:694-698` | PASS |
+| Step table annotations (chore chain) | T2, T6 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:220,222` | PASS |
+| Step table annotations (bug chain) | T2, T6 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:236,238` | PASS |
+| Updated verification checklist | Review fix | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:992` | PASS |
+| Updated "every fork" preamble (chore chain) | Review fix | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:635` | PASS |
+| Updated "every fork" preamble (bug chain) | Review fix | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md:686` | PASS |
+| New test fixture `bug-high-rc-only.md` | Review fix | `scripts/__tests__/fixtures/feat-014/bug-high-rc-only.md` | PASS |
+| Chore document | CHORE-031 | `requirements/chores/CHORE-031-tighten-classifier-skip-steps.md` | PASS |
+| Vitest worktree exclusion | Bonus fix | `vitest.config.ts:6` | PASS |
+
+## Plan Completeness Checklist
+
+- [x] All existing tests pass (regression baseline)
+- [x] All FR-N / RC-N / AC entries have corresponding test plan entries
+- [x] Coverage gaps are identified with recommendations
+- [x] Code paths trace from requirements to implementation
+- [x] Phase deliverables are accounted for (if applicable)
+- [x] New test recommendations are actionable and prioritized

--- a/qa/test-results/QA-results-CHORE-031.md
+++ b/qa/test-results/QA-results-CHORE-031.md
@@ -1,0 +1,88 @@
+# QA Results: Tighten Bug Classifier and Skip Unnecessary Fork Steps
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Results ID** | QA-results-CHORE-031 |
+| **Requirement Type** | CHORE |
+| **Requirement ID** | CHORE-031 |
+| **Source Test Plan** | `qa/test-plans/QA-plan-CHORE-031.md` |
+| **Date** | 2026-04-12 |
+| **Verdict** | PASS |
+| **Verification Iterations** | 2 |
+
+## Per-Entry Verification Results
+
+Direct verification of each test plan entry:
+
+| # | Test Description | Target File(s) | Requirement Ref | Result | Notes |
+|---|-----------------|----------------|-----------------|--------|-------|
+| 1 | Bug classifier suite — 7 tests | `workflow-state.test.ts` | AC-1 | PASS | 7 `it()` entries in describe block confirmed |
+| 2 | `${CLAUDE_SKILL_DIR}` ref count = 66 | `orchestrating-workflows.test.ts:70` | AC-3, AC-4 | PASS | `toBe(66)` confirmed |
+| 3 | Chore chain lifecycle 9-step | `orchestrating-workflows.test.ts` | AC-3, AC-4 | PASS | Full 9-step advance confirmed |
+| 4 | Bug chain lifecycle 9-step | `orchestrating-workflows.test.ts` | AC-3, AC-4 | PASS | Full 9-step advance confirmed |
+| 5 | FEAT-014 adaptive model selection A, B, C | `orchestrating-workflows.test.ts` | AC-5 | PASS | All 3 examples present |
+| 6 | Feature init classifier — 6 tests | `workflow-state.test.ts` | AC-5 | PASS | 6 tests confirmed (plan corrected from 5) |
+| 7 | Chore classifier — 6 tests | `workflow-state.test.ts` | AC-5 | PASS | 6 tests confirmed (plan corrected from 5) |
+| 8 | Critical severity caps at medium | `workflow-state.test.ts` + `bug-critical-severity.md` | AC-1 | PASS | Test at line 1116, asserts `medium` |
+| 9 | RC count 4 alone caps at medium | `workflow-state.test.ts` + `bug-max-severity-rc.md` | AC-1 | PASS | Test at line 1128, asserts `medium` |
+| 10 | High severity + 4 RCs + logic-error → high | `workflow-state.test.ts` + `bug-high-rc-only.md` | AC-1, AC-2 | PASS | Test at line 1135, asserts `high` |
+| 11 | High severity + 3 RCs + security → high | `workflow-state.test.ts` + `bug-high.md` | AC-5 | PASS | Test at line 1111, asserts `high` (unchanged) |
+| 12 | Ref count assertion = 66 | `orchestrating-workflows.test.ts:70` | AC-3, AC-4 | PASS | Matches 66 SKILL.md references |
+| 13 | AC-1: T1 guard at workflow-state.sh:531-540 | `workflow-state.sh` | AC-1 | PASS | Guard logic verified by code inspection |
+| 14 | AC-2: BUG-009-equivalent → medium | `workflow-state.sh` | AC-2 | PASS | Logic trace: sev=high, 1 RC, no cat bump → capped to medium |
+| 15 | AC-3: Step 2 skip on low complexity | `SKILL.md:637-641, 688-692` | AC-3 | PASS | Skip condition + advance call confirmed in both chains |
+| 16 | AC-4: Step 4 skip on low complexity | `SKILL.md:643-647, 694-698` | AC-4 | PASS | Skip condition + advance call confirmed in both chains |
+| 17 | AC-5: Feature chain unchanged | `SKILL.md:198-211, 607-632` | AC-5 | PASS | No CHORE-031 annotations in feature chain sections |
+| 18-30 | Deliverable verification (13 items) | Various | All ACs | PASS | All deliverables present at expected paths |
+
+### Summary
+
+- **Total entries:** 30
+- **Passed:** 30
+- **Failed:** 0
+- **Skipped:** 0
+
+## Test Suite Results
+
+| Metric | Count |
+|--------|-------|
+| **Total Tests** | 702 |
+| **Passed** | 702 |
+| **Failed** | 0 |
+| **Errors** | 0 |
+
+## Issues Found and Fixed
+
+| Entry # | Issue | Resolution | Iteration Fixed |
+|---------|-------|-----------|-----------------|
+| 6 | Test plan stated feature init classifier has 5 tests; actually has 6 | Corrected test plan count to 6 | 2 |
+| 7 | Test plan stated chore classifier has 5 tests; actually has 6 | Corrected test plan count to 6 | 2 |
+
+## Reconciliation Summary
+
+### Changes Made to Requirements Documents
+
+| Document | Section | Change |
+|----------|---------|--------|
+| `requirements/chores/CHORE-031-tighten-classifier-skip-steps.md` | Description | Removed stale "no cross-reference mapping sections" clause — T6 now gates solely on `complexity == low` per code review fix |
+
+### Affected Files Updates
+
+| Document | Files Added | Files Removed |
+|----------|------------|---------------|
+| `requirements/chores/CHORE-031-tighten-classifier-skip-steps.md` | None (test files, fixtures, and vitest.config.ts are supporting changes, not core affected files) | None |
+
+### Acceptance Criteria Modifications
+
+| AC | Original | Updated | Reason |
+|----|----------|---------|--------|
+| AC-4 | "Test-plan reconciliation fork is skipped when the plan has no cross-reference mapping sections or `complexity == low`" | "Test-plan reconciliation fork is skipped when `complexity == low`" | Code review found the grep regex `^##+ .*[Mm]apping` matched nothing in any QA plan; condition simplified to complexity-only gate |
+
+## Deviation Notes
+
+| Area | Planned | Actual | Rationale |
+|------|---------|--------|-----------|
+| T6 skip condition | Gate on `complexity == low` OR no mapping sections in QA plan | Gate on `complexity == low` only | Code review identified that the grep regex for mapping sections matched zero headings in the QA template — the condition was always true, silently disabling step 4 for all complexity levels. Simplified to complexity-only gate. |
+| Vitest config | Not planned | Added `.claude/worktrees/**` to vitest exclude | Stale worktree copies were being picked up by vitest glob, causing spurious test failures |

--- a/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
+++ b/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
@@ -1,0 +1,44 @@
+# Chore: Tighten Bug Classifier and Skip Unnecessary Fork Steps
+
+## Chore ID
+
+`CHORE-031`
+
+## GitHub Issue
+
+[#138](https://github.com/lwndev/lwndev-marketplace/issues/138)
+
+## Category
+
+`refactoring`
+
+## Description
+
+Refactor `_classify_bug` in `workflow-state.sh` so that severity alone or RC count alone cannot promote a bug to `high` complexity (which forces Opus). Then make the orchestrator skip `reviewing-requirements` standard review (step 2) on `complexity == low` bug/chore chains and skip test-plan reconciliation (step 4) when the plan has no cross-reference mapping sections or `complexity == low`.
+
+## Affected Files
+
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh`
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`
+
+## Acceptance Criteria
+
+- [x] `_classify_bug` no longer returns `high` from severity alone or RC count alone
+- [x] A BUG-009-equivalent bug (documentation category, 1-line fix, severity=high) resolves to `sonnet`
+- [x] Bug/chore chains with `complexity == low` skip `reviewing-requirements` step 2
+- [x] Test-plan reconciliation fork is skipped when the plan has no cross-reference mapping sections or `complexity == low`
+- [x] Feature-chain behavior is unchanged by all of the above
+
+## Completion
+
+**Status:** `In Progress`
+
+**Completed:** 2026-04-12
+
+**Pull Request:** TBD
+
+## Notes
+
+- This bundles T1, T2, and T6 from the parent issue #137. T2 and T6 are downstream consumers of T1's classifier output, so they should ship together as one testable unit.
+- The `_classify_bug` change requires both severity >= medium AND (rc_count >= 4 OR category in {security, performance}) to return `high`. Raw severity alone tops out at `medium`. RC count alone maxes at `medium`.
+- The step-skipping changes only affect bug and chore chains. Feature chains must remain untouched.

--- a/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
+++ b/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
@@ -35,7 +35,7 @@ Refactor `_classify_bug` in `workflow-state.sh` so that severity alone or RC cou
 
 **Completed:** 2026-04-12
 
-**Pull Request:** TBD
+**Pull Request:** [#141](https://github.com/lwndev/lwndev-marketplace/pull/141)
 
 ## Notes
 

--- a/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
+++ b/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
@@ -14,7 +14,7 @@
 
 ## Description
 
-Refactor `_classify_bug` in `workflow-state.sh` so that severity alone or RC count alone cannot promote a bug to `high` complexity (which forces Opus). Then make the orchestrator skip `reviewing-requirements` standard review (step 2) on `complexity == low` bug/chore chains and skip test-plan reconciliation (step 4) when the plan has no cross-reference mapping sections or `complexity == low`.
+Refactor `_classify_bug` in `workflow-state.sh` so that severity alone or RC count alone cannot promote a bug to `high` complexity (which forces Opus). Then make the orchestrator skip `reviewing-requirements` standard review (step 2) and test-plan reconciliation (step 4) on `complexity == low` bug/chore chains.
 
 ## Affected Files
 

--- a/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
+++ b/requirements/chores/CHORE-031-tighten-classifier-skip-steps.md
@@ -26,12 +26,12 @@ Refactor `_classify_bug` in `workflow-state.sh` so that severity alone or RC cou
 - [x] `_classify_bug` no longer returns `high` from severity alone or RC count alone
 - [x] A BUG-009-equivalent bug (documentation category, 1-line fix, severity=high) resolves to `sonnet`
 - [x] Bug/chore chains with `complexity == low` skip `reviewing-requirements` step 2
-- [x] Test-plan reconciliation fork is skipped when the plan has no cross-reference mapping sections or `complexity == low`
+- [x] Test-plan reconciliation fork is skipped when `complexity == low`
 - [x] Feature-chain behavior is unchanged by all of the above
 
 ## Completion
 
-**Status:** `In Progress`
+**Status:** `Completed`
 
 **Completed:** 2026-04-12
 

--- a/scripts/__tests__/fixtures/feat-014/bug-critical-severity.md
+++ b/scripts/__tests__/fixtures/feat-014/bug-critical-severity.md
@@ -14,7 +14,7 @@
 
 ## Description
 
-Synthetic bug fixture exercising the `critical` severity alias (maps to `high`). One root cause keeps RC-count at `low`, but severity wins the `max`. Classifier should return `high`.
+Synthetic bug fixture exercising the `critical` severity alias (maps to `high` sev_tier). One root cause keeps RC-count at `low`, and category is `logic-error` (no bump). Under CHORE-031 T1, severity alone cannot promote to `high` — capped at `medium`.
 
 ## Root Cause(s)
 

--- a/scripts/__tests__/fixtures/feat-014/bug-high-rc-only.md
+++ b/scripts/__tests__/fixtures/feat-014/bug-high-rc-only.md
@@ -1,0 +1,28 @@
+# Bug: High via RC Count + Severity (No Category Bump)
+
+## Bug ID
+
+`BUG-907`
+
+## Category
+
+`logic-error`
+
+## Severity
+
+`high`
+
+## Description
+
+Synthetic fixture exercising the `rc_tier=high` branch of the CHORE-031 T1 guard without a category bump. Severity `high` (sev_rank=3) meets the `>= medium` requirement, and 4 root causes push rc_tier to `high`, satisfying the escalation signal. Category is `logic-error` (no bump). Classifier should return `high`.
+
+## Root Cause(s)
+
+1. First independent defect in module A.
+2. Second independent defect in module B.
+3. Third independent defect in module C.
+4. Fourth independent defect in module D.
+
+## Acceptance Criteria
+
+- [ ] Each defect is independently fixed (RC-1, RC-2, RC-3, RC-4)

--- a/scripts/__tests__/fixtures/feat-014/bug-max-severity-rc.md
+++ b/scripts/__tests__/fixtures/feat-014/bug-max-severity-rc.md
@@ -14,7 +14,7 @@
 
 ## Description
 
-Synthetic fixture exercising `max(severity, RC count)`. Severity is `low`, but four distinct root causes push RC bucket to `high`. `max(low, high) = high`. Category is logic-error so no bump. Classifier should return `high`.
+Synthetic fixture exercising `max(severity, RC count)`. Severity is `low`, four distinct root causes push RC bucket to `high`. Under CHORE-031 T1, severity must be ≥ medium for the result to reach `high` — since severity is `low`, the result is capped at `medium` despite 4 RCs.
 
 ## Root Cause(s)
 

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -67,7 +67,7 @@ describe('orchestrating-workflows skill', () => {
       // All references should use ${CLAUDE_SKILL_DIR}/ prefix
       const prefixedRefs = body.match(/\$\{CLAUDE_SKILL_DIR\}\/scripts\/workflow-state\.sh/g);
       expect(prefixedRefs).not.toBeNull();
-      expect(prefixedRefs!.length).toBe(62);
+      expect(prefixedRefs!.length).toBe(66);
     });
 
     it('should include "When to Use This Skill" section', () => {

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -1131,6 +1131,11 @@ describe('workflow-state.sh', () => {
             'medium'
           );
         });
+
+        it('high severity + 4 RCs + logic-error → high via rc_tier branch (CHORE-031 T1)', () => {
+          runJSON('init BUG-001 bug');
+          expect(run(`classify-init BUG-001 ${fixturePath('bug-high-rc-only.md')}`)).toBe('high');
+        });
       });
 
       // --- feature init-stage extractor tests ---

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -1113,10 +1113,10 @@ describe('workflow-state.sh', () => {
           expect(run(`classify-init BUG-001 ${fixturePath('bug-high.md')}`)).toBe('high');
         });
 
-        it('critical severity alias maps to high even with 1 RC', () => {
+        it('critical severity alone caps at medium (CHORE-031 T1)', () => {
           runJSON('init BUG-001 bug');
           expect(run(`classify-init BUG-001 ${fixturePath('bug-critical-severity.md')}`)).toBe(
-            'high'
+            'medium'
           );
         });
 
@@ -1125,10 +1125,10 @@ describe('workflow-state.sh', () => {
           expect(run(`classify-init BUG-001 ${fixturePath('bug-perf-bump.md')}`)).toBe('medium');
         });
 
-        it('max(severity low, RC count 4 → high) = high', () => {
+        it('RC count 4 alone caps at medium when severity is low (CHORE-031 T1)', () => {
           runJSON('init BUG-001 bug');
           expect(run(`classify-init BUG-001 ${fixturePath('bug-max-severity-rc.md')}`)).toBe(
-            'high'
+            'medium'
           );
         });
       });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testMatch: ['**/__tests__/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '.claude/worktrees/**'],
     fileParallelism: false,
     coverage: {
       include: ['scripts/**/*.ts'],


### PR DESCRIPTION
## Chore
[CHORE-031](requirements/chores/CHORE-031-tighten-classifier-skip-steps.md)

## Summary
Prevents `_classify_bug` from promoting simple bugs to Opus by requiring both severity >= medium AND an escalation signal (high RC count or security/performance category). Also makes the orchestrator skip unnecessary `reviewing-requirements` forks on low-complexity bug/chore chains.

## Changes
- **T1**: Refactored `_classify_bug` in `workflow-state.sh` — severity alone or RC count alone now caps at `medium` (sonnet). Reaching `high` (opus) requires both severity >= medium AND (rc_count >= 4 OR security/performance category bump)
- **T2**: Bug/chore chain step 2 (`reviewing-requirements` standard review) is skipped when `complexity == low`
- **T6**: Bug/chore chain step 4 (test-plan reconciliation) is skipped when `complexity == low` or the QA plan has no mapping sections
- Updated 2 test fixtures and 2 test assertions to reflect the tightened classifier
- Feature-chain behavior is unchanged

## Testing
- [x] Tests pass (701/701)
- [x] Build/validation succeeds (13/13 skills)
- [x] Linting passes

## Related
- Closes #138

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)