### PR TITLE
release(lwndev-sdlc): v1.8.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.8.2"
+      "version": "1.8.3"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.8.3] - 2026-04-12
+
+### Documentation
+
+- **qa:** add QA test plan and results for BUG-010
+
+### Bug Fixes
+
+- **stop-hooks:** add state-file gates to `documenting-qa` and `executing-qa` stop hooks to prevent cross-fire with unrelated skills (BUG-010)
+
+[1.8.3]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.8.2...lwndev-sdlc@1.8.3
+
 ## [1.8.2] - 2026-04-12
 
 ### Chores

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.8.2 | **Released:** 2026-04-12
+**Version:** 1.8.3 | **Released:** 2026-04-12
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary
- Bump lwndev-sdlc from 1.8.2 to 1.8.3 (patch)

## Changes since v1.8.2
- **Bug fix:** Add state-file gates to `documenting-qa` and `executing-qa` stop hooks to prevent cross-fire with unrelated skills (BUG-010, #143)
- **Docs:** QA test plan and results for BUG-010