### PR TITLE
release(lwndev-sdlc): v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.8.4"
+      "version": "1.9.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.9.0] - 2026-04-12
+
+### Documentation
+
+- **qa:** add QA test results for FEAT-015
+- **FEAT-015:** add requirements and QA test plan artifacts
+
+### Bug Fixes
+
+- **refs:** update review-findings resume handler for FEAT-015 changes
+
+### Chores
+
+- **FEAT-015:** mark Phase 1 complete and check off deliverables
+
+### Features
+
+- **FEAT-015:** add chain-type/complexity gate to findings-handling decision flow
+
+[1.9.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.8.4...lwndev-sdlc@1.9.0
+
 ## [1.8.4] - 2026-04-12
 
 ### Documentation

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.8.4 | **Released:** 2026-04-12
+**Version:** 1.9.0 | **Released:** 2026-04-12
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary
- Auto-advance on warnings-only findings for bug/chore chains at complexity <= medium (FEAT-015)
- Enforce no-edits-after-re-run rule with explicit three-outcome enumeration
- Update review-findings resume handler in chain-procedures.md

## Changes
- **feat**: chain-type/complexity gate in findings-handling decision flow
- **fix**: stale review-findings resume handler in chain-procedures.md
- **docs**: FEAT-015 requirements, implementation plan, QA artifacts

## Checklist
- [x] Version bumped to 1.9.0 in plugin.json, marketplace.json, README.md
- [x] Changelog updated
- [x] All tests pass (715/715)

🤖 Generated with [Claude Code](https://claude.ai/code)