### PR TITLE
fix(logic-error): add gate mechanism to stop findings feedback loop (BUG-011)

### DIFF
--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -276,16 +276,32 @@ Based on the parsed counts, follow this flow:
      [info] {N} warnings, {N} info from reviewing-requirements ({mode}) — auto-advancing (chain={type}, complexity={complexity})
      ```
      Display the full findings to the user (for visibility), emit the `[info]` line above, then advance state. Do not prompt.
-   - **Bug or chore chain with `complexity == high`**, or **any feature chain** → Display the full findings to the user. Prompt: "{N} warnings and {N} info found by reviewing-requirements. Review findings above and continue? (yes / no)". If the user confirms, advance state. If the user declines, pause the workflow:
+   - **Bug or chore chain with `complexity == high`**, or **any feature chain** → Display the full findings to the user. Set the gate before prompting so the stop hook does not nudge while waiting for input:
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh set-gate {ID} findings-decision
+     ```
+     Prompt: "{N} warnings and {N} info found by reviewing-requirements. Review findings above and continue? (yes / no)". After the user responds, clear the gate:
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ```
+     If the user confirms, advance state. If the user declines, pause the workflow:
      ```bash
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution. The user re-invokes with `/orchestrating-workflows {ID}` after addressing findings manually.
 
-3. **Errors present** → Display the full findings to the user. List the auto-fixable items from the "Fix Summary" / "Update Summary" section of the findings. Errors always block progression — present two options:
-   - **Apply fixes** → The orchestrator applies the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). Parse the re-run findings per the rules in "Applying Auto-Fixes" below.
-   - **Pause for manual resolution** → Pause immediately:
+3. **Errors present** → Display the full findings to the user. List the auto-fixable items from the "Fix Summary" / "Update Summary" section of the findings. Errors always block progression — set the gate before presenting options so the stop hook does not nudge while waiting for input:
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh set-gate {ID} findings-decision
+   ```
+   Present two options:
+   - **Apply fixes** → Clear the gate, then apply the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). Parse the re-run findings per the rules in "Applying Auto-Fixes" below.
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ```
+   - **Pause for manual resolution** → Clear the gate, then pause immediately:
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution.

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -295,28 +295,30 @@ Based on the parsed counts, follow this flow:
    ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh set-gate {ID} findings-decision
    ```
    Present two options:
-   - **Apply fixes** → Clear the gate, then apply the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). Parse the re-run findings per the rules in "Applying Auto-Fixes" below.
+   - **Apply fixes** → Keep the gate active during fix application and re-verification (the gate suppresses stop-hook nudges for the entire fix+re-run cycle). Apply the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). The gate is cleared after the re-run completes and the outcome is determined — see "Applying Auto-Fixes" below.
+   - **Pause for manual resolution** → Pause immediately (the `pause` command clears the gate automatically):
      ```bash
-     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
-     ```
-   - **Pause for manual resolution** → Clear the gate, then pause immediately:
-     ```bash
-     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution.
 
 #### Applying Auto-Fixes
 
-When the user opts to apply fixes, the orchestrator (not a subagent) applies them:
+When the user opts to apply fixes, the orchestrator (not a subagent) applies them. The gate remains active throughout this entire sequence to suppress stop-hook nudges:
 
 1. Read the auto-fixable items from the findings (listed under "Auto-fixable" or "Applicable updates" in the subagent's return text)
 2. For each fix, use the Edit tool to apply the correction to the target file
 3. After all fixes are applied, spawn a new `reviewing-requirements` subagent fork with the same arguments as the original step to re-verify
-4. This re-run is the single allowed retry. After the re-run completes, **do not apply any further edits regardless of what the re-run findings contain**:
-   - If the re-run returns zero errors → advance state.
-   - If the re-run returns warnings/info only (zero errors) → advance state unconditionally. Zero errors after a fix pass means the fixes succeeded; residual warnings are accepted.
-   - If the re-run returns errors → display the remaining findings and pause with `review-findings`. Do not attempt to fix the errors.
+4. This re-run is the single allowed retry. After the re-run completes, clear the gate and act on the outcome — **do not apply any further edits regardless of what the re-run findings contain**:
+   - If the re-run returns zero errors → clear the gate, then advance state.
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ```
+   - If the re-run returns warnings/info only (zero errors) → clear the gate, then advance state unconditionally. Zero errors after a fix pass means the fixes succeeded; residual warnings are accepted.
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ```
+   - If the re-run returns errors → display the remaining findings, then pause with `review-findings` (the `pause` command clears the gate automatically). Do not attempt to fix the errors.
      ```bash
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh
@@ -48,6 +48,12 @@ case "$STATUS" in
       exit 0
     fi
 
+    # If a gate is active, the orchestrator is waiting for user input — allow stop
+    GATE="$(echo "$STATE_JSON" | jq -r '.gate // empty')"
+    if [[ -n "$GATE" ]]; then
+      exit 0
+    fi
+
     echo "Workflow ${WORKFLOW_ID} is ${STATUS}. Continue to step $((CURRENT_STEP + 1)): ${NEXT_DESC}" >&2
     exit 2
     ;;

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -61,6 +61,9 @@ usage() {
   echo "                                (default 2.1.72). Exits 0 if current >= required or if version" >&2
   echo "                                cannot be determined (graceful). Exits 1 if current < required" >&2
   echo "                                and emits the documented warning line to stderr." >&2
+  echo "  set-gate <ID> <gate-type>     Signal that the orchestrator is waiting for user input within an" >&2
+  echo "                                in-progress step. Valid gate types: findings-decision." >&2
+  echo "  clear-gate <ID>               Remove the active gate (sets gate to null)." >&2
   exit 1
 }
 
@@ -189,7 +192,8 @@ _migrate_state_file() {
     (has("complexity") | not) or
     (has("complexityStage") | not) or
     (has("modelOverride") | not) or
-    (has("modelSelections") | not)
+    (has("modelSelections") | not) or
+    (has("gate") | not)
   ' "$file" 2>/dev/null || echo "false")
 
   if [[ "$needs_migration" != "true" ]]; then
@@ -203,6 +207,7 @@ _migrate_state_file() {
     | (if has("complexityStage") | not then .complexityStage = "init" else . end)
     | (if has("modelOverride") | not then .modelOverride = null else . end)
     | (if has("modelSelections") | not then .modelSelections = [] else . end)
+    | (if has("gate") | not then .gate = null else . end)
   ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 }
 
@@ -895,6 +900,7 @@ cmd_init() {
       currentStep: 0,
       status: "in-progress",
       pauseReason: null,
+      gate: null,
       steps: $steps,
       phases: { total: 0, completed: 0 },
       prNumber: null,
@@ -954,7 +960,8 @@ cmd_advance() {
     '.steps[$step].status = "complete"
      | .steps[$step].completedAt = $now
      | (if $artifact != null then .steps[$step].artifact = $artifact else . end)
-     | .currentStep = $next' \
+     | .currentStep = $next
+     | .gate = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   # Update phase completion count if the completed step had a phaseNumber
@@ -981,7 +988,7 @@ cmd_pause() {
   fi
 
   jq --arg reason "$reason" \
-    '.status = "paused" | .pauseReason = $reason' \
+    '.status = "paused" | .pauseReason = $reason | .gate = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"
@@ -1000,8 +1007,39 @@ cmd_resume() {
   current_step=$(jq -r '.currentStep' "$file")
 
   jq --arg now "$now" --argjson step "$current_step" \
-    '.status = "in-progress" | .pauseReason = null | .error = null | .lastResumedAt = $now
+    '.status = "in-progress" | .pauseReason = null | .gate = null | .error = null | .lastResumedAt = $now
      | if .steps[$step].status == "failed" then .steps[$step].status = "pending" else . end' \
+    "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+
+  cat "$file"
+}
+
+cmd_set_gate() {
+  local id="$1"
+  local gate_type="$2"
+  local file
+  file=$(state_file "$id")
+  validate_state_file "$file"
+
+  if [[ "$gate_type" != "findings-decision" ]]; then
+    echo "Error: Invalid gate type '${gate_type}'. Expected 'findings-decision'." >&2
+    exit 1
+  fi
+
+  jq --arg gate "$gate_type" \
+    '.gate = $gate' \
+    "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+
+  cat "$file"
+}
+
+cmd_clear_gate() {
+  local id="$1"
+  local file
+  file=$(state_file "$id")
+  validate_state_file "$file"
+
+  jq '.gate = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"
@@ -1515,6 +1553,14 @@ case "$command" in
     ;;
   check-claude-version)
     cmd_check_claude_version "${1:-}"
+    ;;
+  set-gate)
+    [[ $# -ge 2 ]] || { echo "Error: set-gate requires <ID> <gate-type>" >&2; exit 1; }
+    cmd_set_gate "$1" "$2"
+    ;;
+  clear-gate)
+    [[ $# -ge 1 ]] || { echo "Error: clear-gate requires <ID>" >&2; exit 1; }
+    cmd_clear_gate "$1"
     ;;
   *)
     echo "Error: Unknown command '${command}'" >&2

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -178,10 +178,10 @@ _step_baseline_locked() {
   esac
 }
 
-# Defensive migration for pre-existing state files missing FEAT-014 fields (FR-13).
-# Adds complexity, complexityStage, modelOverride, and modelSelections with their init
-# defaults when any of them are missing. Silent except for a single stderr debug line
-# the first time a file is actually rewritten.
+# Defensive migration for pre-existing state files missing required fields.
+# Adds complexity, complexityStage, modelOverride, modelSelections (FEAT-014 FR-13),
+# and gate (BUG-011) with their init defaults when any are missing. Silent except for
+# a single stderr debug line the first time a file is actually rewritten.
 _migrate_state_file() {
   local file="$1"
   [[ -f "$file" ]] || return 0
@@ -200,7 +200,7 @@ _migrate_state_file() {
     return 0
   fi
 
-  echo "[workflow-state] debug: migrating ${file} to add FEAT-014 model-selection fields" >&2
+  echo "[workflow-state] debug: migrating ${file} to add missing state fields (model-selection and gate)" >&2
 
   jq '
     (if has("complexity") | not then .complexity = null else . end)
@@ -1021,6 +1021,13 @@ cmd_set_gate() {
   file=$(state_file "$id")
   validate_state_file "$file"
 
+  local current_status
+  current_status=$(jq -r '.status' "$file")
+  if [[ "$current_status" != "in-progress" ]]; then
+    echo "Error: Cannot set gate on a ${current_status} workflow. Gate is only valid for in-progress workflows." >&2
+    exit 1
+  fi
+
   if [[ "$gate_type" != "findings-decision" ]]; then
     echo "Error: Invalid gate type '${gate_type}'. Expected 'findings-decision'." >&2
     exit 1
@@ -1056,7 +1063,7 @@ cmd_fail() {
   current_step=$(jq -r '.currentStep' "$file")
 
   jq --arg msg "$message" --argjson step "$current_step" \
-    '.status = "failed" | .error = $msg | .steps[$step].status = "failed"' \
+    '.status = "failed" | .error = $msg | .steps[$step].status = "failed" | .gate = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"

--- a/qa/test-plans/QA-plan-BUG-011.md
+++ b/qa/test-plans/QA-plan-BUG-011.md
@@ -1,0 +1,80 @@
+# QA Test Plan: Stop Hook Findings Feedback Loop Fix
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Plan ID** | QA-plan-BUG-011 |
+| **Requirement Type** | BUG |
+| **Requirement ID** | BUG-011 |
+| **Source Documents** | `requirements/bugs/BUG-011-stop-hook-findings-loop.md` |
+| **Date Created** | 2026-04-12 |
+
+## Existing Test Verification
+
+Tests that already exist and must continue to pass (regression baseline):
+
+| Test File | Description | Status |
+|-----------|-------------|--------|
+| `scripts/__tests__/workflow-state.test.ts` | Workflow state management tests (init, advance, pause, resume, fail, complete, set-pr, populate-phases, phase-count, set-complexity, model selection) | PASS |
+| `scripts/__tests__/orchestrating-workflows.test.ts` | Orchestrating workflows skill structure, SKILL.md validation, stop-hook existence, reference files, model selection audit trail | PASS |
+
+## New Test Analysis
+
+New or modified tests that should be created or verified during QA execution:
+
+| Test Description | Target File(s) | Requirement Ref | Priority | Status |
+|-----------------|----------------|-----------------|----------|--------|
+| `set-gate` subcommand sets `gate` field in state JSON | `scripts/workflow-state.sh` | RC-2, AC-1 | High | PASS |
+| `clear-gate` subcommand removes `gate` field from state JSON | `scripts/workflow-state.sh` | RC-2, AC-4 | High | PASS |
+| `set-gate` rejects invalid gate types | `scripts/workflow-state.sh` | RC-2, AC-1 | Medium | PASS |
+| Stop hook exits 0 (allows stop) when state is in-progress with active gate | `scripts/stop-hook.sh` | RC-1, AC-2 | High | PASS |
+| Stop hook exits 2 (blocks stop) when state is in-progress without gate | `scripts/stop-hook.sh` | RC-1, AC-5 | High | PASS |
+| Stop hook exits 0 for paused state (plan-approval) unchanged | `scripts/stop-hook.sh` | AC-6 | Medium | PASS |
+| Stop hook exits 0 for paused state (pr-review) unchanged | `scripts/stop-hook.sh` | AC-6 | Medium | PASS |
+| Stop hook exits 0 for paused state (review-findings) unchanged | `scripts/stop-hook.sh` | AC-6 | Medium | PASS |
+| Gate field survives state file round-trip (set → status → verify present) | `scripts/workflow-state.sh` | RC-2, AC-1 | Medium | PASS |
+| SKILL.md documents gate set/clear instructions at findings decision points | `SKILL.md` | AC-3 | Medium | PASS |
+
+## Coverage Gap Analysis
+
+Code paths and functionality that lack test coverage:
+
+| Gap Description | Affected Code | Requirement Ref | Recommendation |
+|----------------|---------------|-----------------|----------------|
+| No existing tests for stop-hook.sh behavior (only existence check) | `scripts/stop-hook.sh` | RC-1 | Write integration tests that invoke stop-hook.sh with various state file configurations and verify exit codes |
+| No existing tests for gate-related state fields | `scripts/workflow-state.sh` | RC-2 | Add unit tests for `set-gate` and `clear-gate` subcommands |
+| No test covering stop hook + gate interaction | `scripts/stop-hook.sh` + `scripts/workflow-state.sh` | RC-1, RC-2 | Write integration test: set gate → run stop hook → verify exit 0 |
+
+## Code Path Verification
+
+Traceability from requirements to implementation:
+
+| Requirement | Description | Expected Code Path | Verification Method | Status |
+|-------------|-------------|-------------------|-------------------|--------|
+| RC-1 | Stop hook only inspects top-level status, unaware of sub-step gates | `stop-hook.sh:37-58` — `case "$STATUS"` block must add gate check before emitting nudge | Code review + automated test | PASS |
+| RC-2 | State model lacks gate sub-state | `workflow-state.sh` — new `set-gate` / `clear-gate` subcommands must be added, writing `gate` field to state JSON | Code review + automated test | PASS |
+| AC-1 | Gate mechanism exists in workflow state model | `workflow-state.sh` `set-gate` subcommand writes `"gate": "<type>"` to state JSON | Automated test | PASS |
+| AC-2 | Stop hook suppresses nudge when gate is active | `stop-hook.sh` reads `gate` field from state JSON; if non-null, exits 0 | Automated test | PASS |
+| AC-3 | Orchestrator sets gate before presenting findings decisions | `SKILL.md` Reviewing-Requirements Findings Handling section updated with gate-set instruction | Manual review | PASS |
+| AC-4 | Orchestrator clears gate when user responds | `SKILL.md` Reviewing-Requirements Findings Handling section updated with gate-clear instruction | Manual review | PASS |
+| AC-5 | Stop hook still nudges for in-progress without gate | `stop-hook.sh` existing `in-progress` branch continues to exit 2 when no gate is set | Automated test | PASS |
+| AC-6 | Existing pause reasons work unchanged | `stop-hook.sh` `complete|paused` branch unmodified | Automated test | PASS |
+
+## Deliverable Verification
+
+| Deliverable | Source | Expected Path | Status |
+|-------------|--------|---------------|--------|
+| Updated stop-hook.sh with gate awareness | RC-1 fix, AC-5, AC-6 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh` | PASS |
+| Updated workflow-state.sh with set-gate/clear-gate | RC-2 fix | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` | PASS |
+| Updated SKILL.md with gate instructions | AC-3, AC-4 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` | PASS |
+| New/updated tests for gate mechanism | All ACs | `scripts/__tests__/workflow-state.test.ts` and/or `scripts/__tests__/orchestrating-workflows.test.ts` | PASS |
+
+## Plan Completeness Checklist
+
+- [x] All existing tests pass (regression baseline)
+- [x] All FR-N / RC-N / AC entries have corresponding test plan entries
+- [x] Coverage gaps are identified with recommendations
+- [x] Code paths trace from requirements to implementation
+- [x] Phase deliverables are accounted for (if applicable)
+- [x] New test recommendations are actionable and prioritized

--- a/qa/test-results/QA-results-BUG-011.md
+++ b/qa/test-results/QA-results-BUG-011.md
@@ -1,0 +1,79 @@
+# QA Results: Stop Hook Findings Feedback Loop Fix
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Results ID** | QA-results-BUG-011 |
+| **Requirement Type** | BUG |
+| **Requirement ID** | BUG-011 |
+| **Source Test Plan** | `qa/test-plans/QA-plan-BUG-011.md` |
+| **Date** | 2026-04-12 |
+| **Verdict** | PASS |
+| **Verification Iterations** | 1 |
+
+## Per-Entry Verification Results
+
+Direct verification of each test plan entry:
+
+| # | Test Description | Target File(s) | Requirement Ref | Result | Notes |
+|---|-----------------|----------------|-----------------|--------|-------|
+| 1 | `set-gate` sets `gate` field in state JSON | `workflow-state.sh` | RC-2, AC-1 | PASS | Test "sets gate to findings-decision on an in-progress workflow" in workflow-state.test.ts |
+| 2 | `clear-gate` removes `gate` field from state JSON | `workflow-state.sh` | RC-2, AC-4 | PASS | Test "clears an active gate back to null" in workflow-state.test.ts |
+| 3 | `set-gate` rejects invalid gate types | `workflow-state.sh` | RC-2, AC-1 | PASS | Test "rejects invalid gate types" in workflow-state.test.ts |
+| 4 | Stop hook exits 0 with active gate | `stop-hook.sh` | RC-1, AC-2 | PASS | Tests in both workflow-state.test.ts and orchestrating-workflows.test.ts |
+| 5 | Stop hook exits 2 without gate | `stop-hook.sh` | RC-1, AC-5 | PASS | Tests in both test files |
+| 6 | Stop hook exits 0 for paused (plan-approval) | `stop-hook.sh` | AC-6 | PASS | Test in orchestrating-workflows.test.ts |
+| 7 | Stop hook exits 0 for paused (pr-review) | `stop-hook.sh` | AC-6 | PASS | Tests in chore/bug chain sections |
+| 8 | Stop hook exits 0 for paused (review-findings) | `stop-hook.sh` | AC-6 | PASS | Test in workflow-state.test.ts |
+| 9 | Gate field survives state file round-trip | `workflow-state.sh` | RC-2, AC-1 | PASS | "init includes gate field" describe block covers feature, chore, bug |
+| 10 | SKILL.md documents gate set/clear | `SKILL.md` | AC-3 | PASS | `set-gate` and `clear-gate` present at findings decision points |
+
+### Summary
+
+- **Total entries:** 10
+- **Passed:** 10
+- **Failed:** 0
+- **Skipped:** 0
+
+## Test Suite Results
+
+| Metric | Count |
+|--------|-------|
+| **Total Tests** | 743 |
+| **Passed** | 743 |
+| **Failed** | 0 |
+| **Errors** | 0 |
+
+## Issues Found and Fixed
+
+No issues found during verification — all entries passed on the first iteration.
+
+## Reconciliation Summary
+
+### Changes Made to Requirements Documents
+
+| Document | Section | Change |
+|----------|---------|--------|
+| `requirements/bugs/BUG-011-stop-hook-findings-loop.md` | Acceptance Criteria | All 6 ACs checked off (`- [ ]` → `- [x]`) |
+| `requirements/bugs/BUG-011-stop-hook-findings-loop.md` | Completion | Status updated to `Complete`, date set to 2026-04-12, PR linked to #156 |
+
+### Affected Files Updates
+
+| Document | Files Added | Files Removed |
+|----------|------------|---------------|
+| `requirements/bugs/BUG-011-stop-hook-findings-loop.md` | None | None |
+
+Affected files list already accurate — no changes needed.
+
+### Acceptance Criteria Modifications
+
+No ACs were modified, added, or descoped. All original ACs were satisfied as written.
+
+## Deviation Notes
+
+| Area | Planned | Actual | Rationale |
+|------|---------|--------|-----------|
+| `set-gate` status validation | Not in requirements | Added guard rejecting set-gate on paused/failed/complete workflows | Defensive consistency with other mutating commands; identified during code review |
+| `cmd_fail` gate clearing | Not in requirements | `fail` transition clears gate automatically | Consistency with advance/pause/resume; identified during code review |
+| Migration message | FEAT-014 only | Updated to mention both FEAT-014 and BUG-011 fields | Stale comment identified during code review |

--- a/requirements/bugs/BUG-011-stop-hook-findings-loop.md
+++ b/requirements/bugs/BUG-011-stop-hook-findings-loop.md
@@ -1,0 +1,74 @@
+# Bug: Stop Hook Findings Feedback Loop
+
+## Bug ID
+
+`BUG-011`
+
+## GitHub Issue
+
+[#153](https://github.com/lwndev/lwndev-marketplace/issues/153)
+
+## Category
+
+`logic-error`
+
+## Severity
+
+`high`
+
+## Description
+
+The orchestrating-workflows stop hook fires on every assistant response, including responses where the orchestrator is legitimately waiting for user input at a findings-handling decision point. This creates a feedback loop that pressures the agent into bypassing user confirmation and acting unilaterally.
+
+## Steps to Reproduce
+
+1. Start a feature workflow (e.g., FEAT-015)
+2. Reach step 2 (`reviewing-requirements`, standard mode)
+3. Have the review return at least 1 error (which blocks progression per the findings-handling Decision Flow)
+4. The orchestrator presents findings and asks "Apply fixes or pause?"
+5. Observe the stop hook fire on that response: "Workflow FEAT-015 is in-progress. Continue to step 2"
+6. The agent responds to the nudge instead of waiting for user input
+7. Stop hook fires again, creating a spiral
+
+## Expected Behavior
+
+The stop hook should not emit a "continue" nudge when the orchestrator is blocked on a findings gate that requires user input. The agent should be able to wait for user confirmation without being nudged into acting.
+
+## Actual Behavior
+
+The stop hook repeatedly fires "Continue to step 2" on every assistant response during the findings-handling decision point, creating a spiral that eventually pressures the agent into bypassing the user confirmation prompt and applying fixes unilaterally.
+
+## Root Cause(s)
+
+1. The stop hook (`plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh:37-52`) only inspects the top-level workflow `status` field (`in-progress`, `paused`, `complete`, `failed`). When the orchestrator is awaiting user input at a findings gate within an in-progress step, the status remains `in-progress`, so the hook emits a "continue" nudge. The hook has no awareness of sub-step decision gates.
+
+2. The workflow state model (`plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh`) has no concept of a "gate" or "pending input" sub-state. There is no mechanism for the orchestrator to signal that it is legitimately waiting for user input within an in-progress step, so the stop hook cannot distinguish "idle at a step" from "blocked on a user decision within a step".
+
+## Affected Files
+
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh`
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh`
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`
+
+## Acceptance Criteria
+
+- [x] A gate mechanism exists in the workflow state model that allows the orchestrator to signal "waiting for user input" within an in-progress step (RC-2)
+- [x] The stop hook checks for the gate state and suppresses the "continue" nudge when a gate is active (RC-1)
+- [x] The orchestrator sets the gate before presenting findings decisions to the user (RC-1, RC-2)
+- [x] The orchestrator clears the gate when the user responds (proceed or pause) (RC-2)
+- [x] The stop hook still nudges correctly for in-progress workflows that are NOT at a gate (RC-1)
+- [x] Existing pause reasons (`plan-approval`, `pr-review`, `review-findings`) continue to work unchanged (RC-1)
+
+## Completion
+
+**Status:** `Complete`
+
+**Completed:** 2026-04-12
+
+**Pull Request:** [#156](https://github.com/lwndev/lwndev-marketplace/pull/156)
+
+## Notes
+
+- Observed during FEAT-015 workflow execution
+- The findings-handling Decision Flow has three paths (zero findings, warnings-only, errors present) — the gate is relevant for errors-present and warnings-only paths that prompt the user
+- Related to BUG-010 (QA stop hook cross-fire) which addressed a similar stop hook interference pattern in a different context

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -538,6 +538,28 @@ describe('integration tests', () => {
       expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('failed');
     });
+
+    it('exits 0 when gate is active (findings-decision suppresses nudge)', () => {
+      stateJSON('init FEAT-001 feature');
+      stateCmd('set-gate FEAT-001 findings-decision');
+      mkdirSync(join(testDir, '.sdlc/workflows'), { recursive: true });
+      writeFileSync(join(testDir, '.sdlc/workflows/.active'), 'FEAT-001');
+
+      const result = runHook();
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('exits 2 after gate is cleared', () => {
+      stateJSON('init FEAT-001 feature');
+      stateCmd('set-gate FEAT-001 findings-decision');
+      stateCmd('clear-gate FEAT-001');
+      mkdirSync(join(testDir, '.sdlc/workflows'), { recursive: true });
+      writeFileSync(join(testDir, '.sdlc/workflows/.active'), 'FEAT-001');
+
+      const result = runHook();
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('in-progress');
+    });
   });
 
   describe('PR metadata', () => {

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -71,7 +71,7 @@ describe('orchestrating-workflows skill', () => {
       // All references should use ${CLAUDE_SKILL_DIR}/ prefix
       const prefixedRefs = body.match(/\$\{CLAUDE_SKILL_DIR\}\/scripts\/workflow-state\.sh/g);
       expect(prefixedRefs).not.toBeNull();
-      expect(prefixedRefs!.length).toBe(18);
+      expect(prefixedRefs!.length).toBe(23);
     });
 
     it('should include "When to Use This Skill" section', () => {

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -539,6 +539,27 @@ describe('workflow-state.sh', () => {
       const err = run('set-gate FEAT-999 findings-decision', { expectError: true });
       expect(err).toContain('State file not found');
     });
+
+    it('rejects set-gate on a paused workflow', () => {
+      runJSON('init FEAT-001 feature');
+      run('pause FEAT-001 plan-approval');
+      const err = run('set-gate FEAT-001 findings-decision', { expectError: true });
+      expect(err).toContain('Cannot set gate on a paused workflow');
+    });
+
+    it('rejects set-gate on a failed workflow', () => {
+      runJSON('init FEAT-001 feature');
+      run('fail FEAT-001 "step broke"');
+      const err = run('set-gate FEAT-001 findings-decision', { expectError: true });
+      expect(err).toContain('Cannot set gate on a failed workflow');
+    });
+
+    it('rejects set-gate on a complete workflow', () => {
+      runJSON('init FEAT-001 feature');
+      run('complete FEAT-001');
+      const err = run('set-gate FEAT-001 findings-decision', { expectError: true });
+      expect(err).toContain('Cannot set gate on a complete workflow');
+    });
   });
 
   describe('clear-gate', () => {
@@ -584,6 +605,14 @@ describe('workflow-state.sh', () => {
       run('set-gate FEAT-001 findings-decision');
       const state = runJSON('resume FEAT-001');
       expect(state.gate).toBeNull();
+    });
+
+    it('fail clears an active gate', () => {
+      runJSON('init FEAT-001 feature');
+      run('set-gate FEAT-001 findings-decision');
+      const state = runJSON('fail FEAT-001 "step broke"');
+      expect(state.gate).toBeNull();
+      expect(state.status).toBe('failed');
     });
   });
 
@@ -1772,6 +1801,10 @@ const WORKFLOW_STATE = join(
   'plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh'
 );
 
+// Both runHook and runState use cwd: testDir so that relative paths in
+// stop-hook.sh (e.g. ACTIVE_FILE=".sdlc/workflows/.active") resolve inside
+// the isolated temp directory, matching real-world behavior where scripts
+// run from the project root.
 function runHook(): {
   stdout: string;
   stderr: string;

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -521,6 +521,92 @@ describe('workflow-state.sh', () => {
     });
   });
 
+  describe('set-gate', () => {
+    it('sets gate to findings-decision on an in-progress workflow', () => {
+      runJSON('init FEAT-001 feature');
+      const state = runJSON('set-gate FEAT-001 findings-decision');
+      expect(state.gate).toBe('findings-decision');
+      expect(state.status).toBe('in-progress');
+    });
+
+    it('rejects invalid gate types', () => {
+      runJSON('init FEAT-001 feature');
+      const err = run('set-gate FEAT-001 invalid-gate', { expectError: true });
+      expect(err).toContain('Invalid gate type');
+    });
+
+    it('errors when state file not found', () => {
+      const err = run('set-gate FEAT-999 findings-decision', { expectError: true });
+      expect(err).toContain('State file not found');
+    });
+  });
+
+  describe('clear-gate', () => {
+    it('clears an active gate back to null', () => {
+      runJSON('init FEAT-001 feature');
+      run('set-gate FEAT-001 findings-decision');
+      const state = runJSON('clear-gate FEAT-001');
+      expect(state.gate).toBeNull();
+    });
+
+    it('is a no-op when gate is already null', () => {
+      runJSON('init FEAT-001 feature');
+      const state = runJSON('clear-gate FEAT-001');
+      expect(state.gate).toBeNull();
+    });
+
+    it('errors when state file not found', () => {
+      const err = run('clear-gate FEAT-999', { expectError: true });
+      expect(err).toContain('State file not found');
+    });
+  });
+
+  describe('gate cleared by state transitions', () => {
+    it('advance clears an active gate', () => {
+      runJSON('init FEAT-001 feature');
+      run('set-gate FEAT-001 findings-decision');
+      const state = runJSON('advance FEAT-001');
+      expect(state.gate).toBeNull();
+    });
+
+    it('pause clears an active gate', () => {
+      runJSON('init FEAT-001 feature');
+      run('set-gate FEAT-001 findings-decision');
+      const state = runJSON('pause FEAT-001 review-findings');
+      expect(state.gate).toBeNull();
+    });
+
+    it('resume clears an active gate', () => {
+      runJSON('init FEAT-001 feature');
+      run('pause FEAT-001 review-findings');
+      // Manually set gate on the state file to simulate an abnormal state
+      run('resume FEAT-001');
+      run('set-gate FEAT-001 findings-decision');
+      const state = runJSON('resume FEAT-001');
+      expect(state.gate).toBeNull();
+    });
+  });
+
+  describe('init includes gate field', () => {
+    it('new workflow state includes gate: null', () => {
+      const state = runJSON('init FEAT-001 feature');
+      expect(Object.prototype.hasOwnProperty.call(state, 'gate')).toBe(true);
+      expect(state.gate).toBeNull();
+    });
+
+    it('new chore workflow includes gate: null', () => {
+      const state = runJSON('init CHORE-001 chore');
+      expect(Object.prototype.hasOwnProperty.call(state, 'gate')).toBe(true);
+      expect(state.gate).toBeNull();
+    });
+
+    it('new bug workflow includes gate: null', () => {
+      const state = runJSON('init BUG-001 bug');
+      expect(Object.prototype.hasOwnProperty.call(state, 'gate')).toBe(true);
+      expect(state.gate).toBeNull();
+    });
+  });
+
   describe('fail', () => {
     it('sets status to failed with error message', () => {
       runJSON('init FEAT-001 feature');
@@ -1661,5 +1747,137 @@ describe('workflow-state.sh', () => {
       const err = run('fail FEAT-001', { expectError: true });
       expect(err).toContain('fail requires');
     });
+
+    it('errors when set-gate has missing gate-type', () => {
+      runJSON('init FEAT-001 feature');
+      const err = run('set-gate FEAT-001', { expectError: true });
+      expect(err).toContain('set-gate requires');
+    });
+
+    it('errors when clear-gate has missing ID', () => {
+      const err = run('clear-gate', { expectError: true });
+      expect(err).toContain('clear-gate requires');
+    });
+  });
+});
+
+// Stop hook tests
+const STOP_HOOK = join(
+  process.cwd(),
+  'plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/stop-hook.sh'
+);
+
+const WORKFLOW_STATE = join(
+  process.cwd(),
+  'plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh'
+);
+
+function runHook(): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+} {
+  try {
+    const stdout = execSync(`bash "${STOP_HOOK}"`, {
+      cwd: testDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    return { stdout: stdout.trim(), stderr: '', exitCode: 0 };
+  } catch (err) {
+    const e = err as { status?: number; stderr?: Buffer | string; stdout?: Buffer | string };
+    return {
+      stdout: (e.stdout?.toString() ?? '').trim(),
+      stderr: (e.stderr?.toString() ?? '').trim(),
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+function runState(args: string): void {
+  execSync(`bash "${WORKFLOW_STATE}" ${args}`, {
+    cwd: testDir,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, PATH: process.env.PATH },
+  });
+}
+
+function writeActiveFile(id: string): void {
+  mkdirSync(join(testDir, '.sdlc/workflows'), { recursive: true });
+  writeFileSync(join(testDir, '.sdlc/workflows/.active'), id, 'utf-8');
+}
+
+describe('stop-hook.sh', () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'stop-hook-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('allows stop when .active file does not exist', () => {
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('allows stop when .active file is empty', () => {
+    mkdirSync(join(testDir, '.sdlc/workflows'), { recursive: true });
+    writeFileSync(join(testDir, '.sdlc/workflows/.active'), '', 'utf-8');
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('allows stop when workflow is paused', () => {
+    runState('init FEAT-001 feature');
+    runState('pause FEAT-001 review-findings');
+    writeActiveFile('FEAT-001');
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('allows stop when workflow is complete', () => {
+    runState('init FEAT-001 feature');
+    runState('complete FEAT-001');
+    writeActiveFile('FEAT-001');
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('blocks stop when workflow is in-progress with remaining steps', () => {
+    runState('init FEAT-001 feature');
+    writeActiveFile('FEAT-001');
+    const result = runHook();
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('FEAT-001');
+    expect(result.stderr).toContain('in-progress');
+  });
+
+  it('allows stop when gate is active (findings-decision gate suppresses nudge)', () => {
+    runState('init FEAT-001 feature');
+    runState('set-gate FEAT-001 findings-decision');
+    writeActiveFile('FEAT-001');
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
+  it('blocks stop again after gate is cleared', () => {
+    runState('init FEAT-001 feature');
+    runState('set-gate FEAT-001 findings-decision');
+    runState('clear-gate FEAT-001');
+    writeActiveFile('FEAT-001');
+    const result = runHook();
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('in-progress');
+  });
+
+  it('allows stop when .active file references stale/missing state', () => {
+    mkdirSync(join(testDir, '.sdlc/workflows'), { recursive: true });
+    writeFileSync(join(testDir, '.sdlc/workflows/.active'), 'FEAT-999', 'utf-8');
+    const result = runHook();
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `set-gate <ID> <gate-type>` and `clear-gate <ID>` subcommands to `workflow-state.sh`, giving the orchestrator a way to signal it is waiting for user input within an in-progress step
- Updates `stop-hook.sh` to exit 0 (suppress "continue" nudge) whenever a `gate` field is non-null in the workflow state, preventing the feedback loop where repeated stop-hook fires pressured the agent into bypassing the user confirmation prompt
- Updates `SKILL.md` findings decision flow to call `set-gate` before presenting findings decision prompts and `clear-gate` after the user responds (or before pausing)
- `advance`, `pause`, and `resume` transitions automatically clear any active gate so a clean slate is guaranteed at every state boundary
- Adds `gate: null` to the initial state shape and a defensive migration in `_migrate_state_file` for pre-existing state files

## Test plan

- [x] `workflow-state.sh set-gate FEAT-001 findings-decision` sets `.gate = "findings-decision"` in state
- [x] `workflow-state.sh clear-gate FEAT-001` resets `.gate` to null
- [x] Invalid gate type (e.g. `set-gate FEAT-001 bad`) returns error and exits non-zero
- [x] `advance` clears an active gate
- [x] `pause` clears an active gate
- [x] `resume` clears an active gate
- [x] `init` includes `gate: null` for feature, chore, and bug workflows
- [x] Stop hook exits 2 (blocks stop) when workflow is in-progress with no gate
- [x] Stop hook exits 0 (allows stop) when gate is `findings-decision`
- [x] Stop hook exits 0 again after gate is cleared (reverts to normal nudge behavior)
- [x] All 737 tests pass; lint clean

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)