### PR TITLE
feat(FEAT-016): persist reviewing-requirements findings in workflow state

### DIFF
--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -259,11 +259,17 @@ Found **N errors**, **N warnings**, **N info**
 
 Extract the error, warning, and info counts from this line. If the summary line is not found (e.g., the subagent returned "No issues found"), treat as zero errors, zero warnings, zero info.
 
+> **Note**: Anchor the count-extraction regex on the `Found **N errors**` substring rather than the start of the line. Subagent output in test-plan and code-review modes may include a mode prefix (e.g., `"Test-plan reconciliation for {ID}: Found **N errors**..."`) before the counts — anchoring on the substring handles these prefixes correctly.
+
 #### Decision Flow
 
 Based on the parsed counts, follow this flow:
 
-1. **Zero findings** (zero errors, zero warnings, zero info) → Advance state automatically. No user interaction needed.
+1. **Zero findings** (zero errors, zero warnings, zero info) → Persist findings, then advance state automatically. No user interaction needed.
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 0 0 advanced 'No issues found'
+   ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
+   ```
 
 2. **Warnings/info only (zero errors)** → Read chain type and complexity from the state file:
    ```bash
@@ -271,11 +277,17 @@ Based on the parsed counts, follow this flow:
    complexity=$(jq -r '.complexity // "medium"' ".sdlc/workflows/{ID}.json")
    ```
    Apply the gate:
-   - **Bug or chore chain with `complexity == low` or `complexity == medium`** → Log the findings and auto-advance:
+   - **Bug or chore chain with `complexity == low` or `complexity == medium`** → Log the findings and auto-advance. Parse individual findings from the subagent return text using the FR-7 procedure described in the "Parsing Individual Findings for `auto-advanced` Decisions" subsection below, write them to a temp file, then persist and advance:
      ```
      [info] {N} warnings, {N} info from reviewing-requirements ({mode}) — auto-advancing (chain={type}, complexity={complexity})
      ```
-     Display the full findings to the user (for visibility), emit the `[info]` line above, then advance state. Do not prompt.
+     Display the full findings to the user (for visibility), emit the `[info]` line above, then:
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 {W} {I} auto-advanced '{summary}' --details-file /tmp/findings-{ID}-{stepIndex}.json
+     rm -f /tmp/findings-{ID}-{stepIndex}.json
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
+     ```
+     Do not prompt.
    - **Bug or chore chain with `complexity == high`**, or **any feature chain** → Display the full findings to the user. Set the gate before prompting so the stop hook does not nudge while waiting for input:
      ```bash
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh set-gate {ID} findings-decision
@@ -284,8 +296,14 @@ Based on the parsed counts, follow this flow:
      ```bash
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
      ```
-     If the user confirms, advance state. If the user declines, pause the workflow:
+     If the user confirms, persist findings then advance state:
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 {W} {I} user-advanced '{summary}'
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
+     ```
+     If the user declines, persist findings then pause the workflow:
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 {W} {I} paused '{summary}'
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution. The user re-invokes with `/orchestrating-workflows {ID}` after addressing findings manually.
@@ -295,9 +313,14 @@ Based on the parsed counts, follow this flow:
    ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh set-gate {ID} findings-decision
    ```
    Present two options:
-   - **Apply fixes** → Keep the gate active during fix application and re-verification (the gate suppresses stop-hook nudges for the entire fix+re-run cycle). Apply the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). The gate is cleared after the re-run completes and the outcome is determined — see "Applying Auto-Fixes" below.
-   - **Pause for manual resolution** → Pause immediately (the `pause` command clears the gate automatically):
+   - **Apply fixes** → Persist findings at the decision point, then keep the gate active during fix application and re-verification (the gate suppresses stop-hook nudges for the entire fix+re-run cycle):
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} {E} {W} {I} auto-fixed '{summary}'
+     ```
+     Apply the auto-fixable corrections in main context using the Edit tool. Then spawn a **new** `reviewing-requirements` subagent fork to re-verify (this is the re-run, max 1). The gate is cleared after the re-run completes and the outcome is determined — see "Applying Auto-Fixes" below.
+   - **Pause for manual resolution** → Persist findings then pause immediately (the `pause` command clears the gate automatically):
+     ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} {E} {W} {I} paused '{summary}'
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution.
@@ -310,19 +333,63 @@ When the user opts to apply fixes, the orchestrator (not a subagent) applies the
 2. For each fix, use the Edit tool to apply the correction to the target file
 3. After all fixes are applied, spawn a new `reviewing-requirements` subagent fork with the same arguments as the original step to re-verify
 4. This re-run is the single allowed retry. After the re-run completes, clear the gate and act on the outcome — **do not apply any further edits regardless of what the re-run findings contain**:
-   - If the re-run returns zero errors → clear the gate, then advance state.
+   - If the re-run returns zero errors → persist re-run findings, then clear the gate, then advance state.
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 0 0 advanced '{rerun-summary}' --rerun
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
      ```
-   - If the re-run returns warnings/info only (zero errors) → clear the gate, then advance state unconditionally. Zero errors after a fix pass means the fixes succeeded; residual warnings are accepted.
+   - If the re-run returns warnings/info only (zero errors) → parse individual findings using the FR-7 procedure, then persist re-run findings, then clear the gate, then advance state unconditionally. Zero errors after a fix pass means the fixes succeeded; residual warnings are accepted.
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 {W2} {I2} auto-advanced '{rerun-summary}' --rerun --details-file /tmp/findings-{ID}-{stepIndex}.json
+     rm -f /tmp/findings-{ID}-{stepIndex}.json
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
      ```
-   - If the re-run returns errors → display the remaining findings, then pause with `review-findings` (the `pause` command clears the gate automatically). Do not attempt to fix the errors.
+   - If the re-run returns errors → display the remaining findings, then persist re-run findings, then pause with `review-findings` (the `pause` command clears the gate automatically). Do not attempt to fix the errors.
      ```bash
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} {E2} {W2} {I2} paused '{rerun-summary}' --rerun
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh pause {ID} review-findings
      ```
      Halt execution.
+
+#### Persisting Findings
+
+At every reviewing-requirements decision point, call `record-findings` **before** `advance` or `pause` to persist the findings in the workflow state file. The call must always precede the state-transition call so that findings survive even if the transition call fails or the process exits.
+
+##### Decision-to-Call Mapping
+
+| Decision taken | `record-findings` invocation |
+|---|---|
+| Zero findings → auto-advance | `record-findings {ID} {stepIndex} 0 0 0 advanced 'No issues found'` |
+| Warnings/info only → auto-advance (FEAT-015 gate) | `record-findings {ID} {stepIndex} 0 {W} {I} auto-advanced '{summary}' --details-file {tmp}` |
+| Warnings/info only → user confirmed | `record-findings {ID} {stepIndex} 0 {W} {I} user-advanced '{summary}'` |
+| Warnings/info only → user declined | `record-findings {ID} {stepIndex} 0 {W} {I} paused '{summary}'` |
+| Errors present → user chose "Apply fixes" | `record-findings {ID} {stepIndex} {E} {W} {I} auto-fixed '{summary}'` |
+| Errors present → user chose "Pause" | `record-findings {ID} {stepIndex} {E} {W} {I} paused '{summary}'` |
+| Re-run after auto-fix (any outcome) | `record-findings {ID} {stepIndex} {E2} {W2} {I2} {rerun-decision} '{rerun-summary}' --rerun` |
+| Re-run after auto-fix → auto-advanced | (same as above plus `--details-file {tmp}`) |
+
+Notes:
+- `{stepIndex}` is the zero-based index in the `steps` array for the current reviewing-requirements step. Use the chain-step-to-index table: feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6.
+- When the subagent returns `"No issues found"` or `Found **0 errors**, **0 warnings**, **0 info**`, normalize to `'No issues found'` as the canonical summary.
+- The `{summary}` must be passed as a single shell-quoted token. Use single quotes around the summary string to handle embedded special characters.
+
+##### Parsing Individual Findings for `auto-advanced` Decisions
+
+When `decision` is `auto-advanced`, parse individual findings from the subagent return text to build the `--details-file` argument:
+
+1. Scan the subagent return text for lines matching: `**[{W|I}{N}] {category} — {description}**` (or the unbolded variant). The separator is an em dash (`—`, U+2014); accept ASCII double-hyphen (`--`) as a fallback. Map prefix letters: `W` → `"warning"`, `I` → `"info"`.
+2. For each match, extract:
+   - `id` — severity+number token (e.g., `"W1"`, `"I3"`)
+   - `severity` — mapped from prefix letter
+   - `category` — text between `]` and `—`, trimmed
+   - `description` — text after `—` to end of line, trimmed and stripped of trailing bold markers
+3. Write the resulting JSON array to `/tmp/findings-{ID}-{stepIndex}.json`
+4. Pass `--details-file /tmp/findings-{ID}-{stepIndex}.json` to `record-findings`
+5. Remove the temp file after `record-findings` returns
+
+If no individual findings can be parsed despite non-zero counts, write `[]` and log: `[warn] Could not parse individual findings from reviewing-requirements output — recording counts only.`
 
 ### Chain-Specific Step Details
 

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -333,9 +333,9 @@ When the user opts to apply fixes, the orchestrator (not a subagent) applies the
 2. For each fix, use the Edit tool to apply the correction to the target file
 3. After all fixes are applied, spawn a new `reviewing-requirements` subagent fork with the same arguments as the original step to re-verify
 4. This re-run is the single allowed retry. After the re-run completes, clear the gate and act on the outcome — **do not apply any further edits regardless of what the re-run findings contain**:
-   - If the re-run returns zero errors → persist re-run findings, then clear the gate, then advance state.
+   - If the re-run returns zero errors → persist re-run findings, then clear the gate, then advance state. Normalize `{rerun-summary}` to `'No issues found'` when the re-run returns zero counts (see summary normalization note in "Persisting Findings" below).
      ```bash
-     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 0 0 advanced '{rerun-summary}' --rerun
+     ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 0 0 advanced 'No issues found' --rerun
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh clear-gate {ID}
      ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "{artifact-path}"
      ```

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -1151,8 +1151,7 @@ cmd_record_findings() {
       echo "[warn] Could not read details file — recording counts only." >&2
     else
       local details_content
-      details_content=$(cat "$details_file")
-      if jq -e '. | arrays' "$details_file" &>/dev/null; then
+      if details_content=$(jq -e '. | arrays' "$details_file" 2>/dev/null); then
         findings_json=$(echo "$findings_json" | jq --argjson details "$details_content" '. + {details: $details}')
       else
         echo "[warn] Could not read details file — recording counts only." >&2

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -64,6 +64,11 @@ usage() {
   echo "  set-gate <ID> <gate-type>     Signal that the orchestrator is waiting for user input within an" >&2
   echo "                                in-progress step. Valid gate types: findings-decision." >&2
   echo "  clear-gate <ID>               Remove the active gate (sets gate to null)." >&2
+  echo "  record-findings <ID> <stepIndex> <errors> <warnings> <info> <decision> <summary> [--rerun] [--details-file <path>]" >&2
+  echo "                                Persist reviewing-requirements findings on a step entry." >&2
+  echo "                                decision must be one of: advanced, auto-advanced, user-advanced, auto-fixed, paused." >&2
+  echo "                                --rerun writes to rerunFindings instead of findings." >&2
+  echo "                                --details-file is only used when decision is auto-advanced." >&2
   exit 1
 }
 
@@ -1052,6 +1057,116 @@ cmd_clear_gate() {
   cat "$file"
 }
 
+cmd_record_findings() {
+  local id="$1"
+  local step_index="$2"
+  local errors="$3"
+  local warnings="$4"
+  local info="$5"
+  local decision="$6"
+  local summary="$7"
+  shift 7
+
+  # Validate step_index is a non-negative integer.
+  if [[ -z "$step_index" ]] || ! [[ "$step_index" =~ ^[0-9]+$ ]]; then
+    echo "Error: record-findings requires a numeric <stepIndex>; got '${step_index}'." >&2
+    exit 1
+  fi
+
+  # Validate errors, warnings, info are non-negative integers.
+  if [[ -z "$errors" ]] || ! [[ "$errors" =~ ^[0-9]+$ ]]; then
+    echo "Error: record-findings requires a numeric <errors>; got '${errors}'." >&2
+    exit 1
+  fi
+  if [[ -z "$warnings" ]] || ! [[ "$warnings" =~ ^[0-9]+$ ]]; then
+    echo "Error: record-findings requires a numeric <warnings>; got '${warnings}'." >&2
+    exit 1
+  fi
+  if [[ -z "$info" ]] || ! [[ "$info" =~ ^[0-9]+$ ]]; then
+    echo "Error: record-findings requires a numeric <info>; got '${info}'." >&2
+    exit 1
+  fi
+
+  # Validate decision is one of the allowed values.
+  case "$decision" in
+    advanced|auto-advanced|user-advanced|auto-fixed|paused) ;;
+    *)
+      echo "Error: record-findings requires decision to be one of: advanced, auto-advanced, user-advanced, auto-fixed, paused; got '${decision}'." >&2
+      exit 1
+      ;;
+  esac
+
+  # Parse optional flags: --rerun and --details-file <path>.
+  local rerun=false
+  local details_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --rerun)
+        rerun=true
+        shift
+        ;;
+      --details-file)
+        [[ $# -ge 2 ]] || { echo "Error: --details-file requires a path argument." >&2; exit 1; }
+        details_file="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: record-findings unknown flag '${1}'." >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  local file
+  file=$(state_file "$id")
+  validate_state_file "$file"
+
+  # Bounds check: stepIndex must be < length(.steps).
+  local steps_len
+  steps_len=$(jq '.steps | length' "$file")
+  if (( step_index >= steps_len )); then
+    echo "Error: stepIndex ${step_index} out of bounds for workflow ${id} (steps length: ${steps_len})." >&2
+    exit 1
+  fi
+
+  # Determine target field name.
+  local field_name="findings"
+  if [[ "$rerun" == "true" ]]; then
+    field_name="rerunFindings"
+  fi
+
+  # Build the base findings JSON object.
+  local findings_json
+  findings_json=$(jq -n \
+    --argjson errors "$errors" \
+    --argjson warnings "$warnings" \
+    --argjson info "$info" \
+    --arg decision "$decision" \
+    --arg summary "$summary" \
+    '{errors: $errors, warnings: $warnings, info: $info, decision: $decision, summary: $summary}')
+
+  # Handle --details-file: only merge details when decision == "auto-advanced".
+  if [[ -n "$details_file" && "$decision" == "auto-advanced" ]]; then
+    if [[ ! -f "$details_file" ]]; then
+      echo "[warn] Could not read details file — recording counts only." >&2
+    else
+      local details_content
+      details_content=$(cat "$details_file")
+      if jq -e '. | arrays' "$details_file" &>/dev/null; then
+        findings_json=$(echo "$findings_json" | jq --argjson details "$details_content" '. + {details: $details}')
+      else
+        echo "[warn] Could not read details file — recording counts only." >&2
+      fi
+    fi
+  fi
+
+  # Write findings object to the target field on the step entry.
+  jq --argjson idx "$step_index" --argjson obj "$findings_json" \
+    ".steps[\$idx].${field_name} = \$obj" "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+
+  cat "$file"
+}
+
 cmd_fail() {
   local id="$1"
   local message="$2"
@@ -1568,6 +1683,10 @@ case "$command" in
   clear-gate)
     [[ $# -ge 1 ]] || { echo "Error: clear-gate requires <ID>" >&2; exit 1; }
     cmd_clear_gate "$1"
+    ;;
+  record-findings)
+    [[ $# -ge 7 ]] || { echo "Error: record-findings requires <ID> <stepIndex> <errors> <warnings> <info> <decision> <summary> [--rerun] [--details-file <path>]" >&2; exit 1; }
+    cmd_record_findings "$@"
     ;;
   *)
     echo "Error: Unknown command '${command}'" >&2

--- a/requirements/implementation/FEAT-016-persist-review-findings.md
+++ b/requirements/implementation/FEAT-016-persist-review-findings.md
@@ -1,0 +1,247 @@
+# Implementation Plan: Persist Reviewing-Requirements Findings in Workflow State
+
+## Overview
+
+Add findings persistence to the `orchestrating-workflows` skill so that reviewing-requirements results are durably recorded in the workflow state file at every decision point. Currently, parsed severity counts and individual finding details are ephemeral — once the workflow advances past a review step, the only record of what was found is lost. This is especially acute on bug/chore chains where FEAT-015 auto-advances on warnings-only findings without surfacing them interactively.
+
+The change is scoped to two artifacts: a new `record-findings` subcommand in `workflow-state.sh` and prose additions to the "Reviewing-Requirements Findings Handling" section of `orchestrating-workflows/SKILL.md`. No sub-skills are modified, no new state schema fields are introduced beyond `findings`/`rerunFindings` on step entries, and no migration is required for existing workflows.
+
+## Features Summary
+
+| Feature ID | GitHub Issue | Feature Document | Priority | Complexity | Status |
+|------------|--------------|------------------|----------|------------|--------|
+| FEAT-016 | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145) | [FEAT-016-persist-review-findings.md](../features/FEAT-016-persist-review-findings.md) | Medium | Medium | Pending |
+
+## Recommended Build Sequence
+
+The implementation has a natural dependency order: `workflow-state.sh` must expose the `record-findings` subcommand before the `SKILL.md` prose can call it. Phase 1 delivers the subcommand and its unit tests in isolation; Phase 2 adds the orchestrator integration calls.
+
+---
+
+### Phase 1: `record-findings` Subcommand in `workflow-state.sh`
+**Feature:** [FEAT-016](../features/FEAT-016-persist-review-findings.md) | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
+**Status:** 🔄 In Progress
+
+#### Rationale
+
+- The `workflow-state.sh` script is independently testable via the existing vitest harness in `scripts/__tests__/workflow-state.test.ts`. Implementing `record-findings` here first means Phase 2's prose changes can be validated with a working subcommand already on disk.
+- All JSON serialization decisions (numeric count fields, conditional `details` inclusion, `rerunFindings` placement alongside `findings`) are encoded in the shell script once, keeping the SKILL.md prose concise.
+- The subcommand's out-of-bounds guard, shell-special-character safety, and `--details-file` validation are mechanical invariants that belong in the script layer, not in orchestrator prose.
+- This phase is independently mergeable — the subcommand can sit in `workflow-state.sh` with no callers until Phase 2 adds the call sites.
+
+#### Implementation Steps
+
+1. **Add `record-findings` to the `usage()` function** (between the `clear-gate` entry and the closing `exit 1`) with the exact signature from FR-4:
+   ```
+   record-findings <ID> <stepIndex> <errors> <warnings> <info> <decision> <summary> [--rerun] [--details-file <path>]
+   ```
+   Follow the existing multi-line echo style used by other long-form entries (e.g., `record-model-selection`, `classify-init`).
+
+2. **Implement `cmd_record_findings()`** as a new function in the script, placed near `cmd_record_model_selection()` for proximity with other step-mutation helpers. The function must:
+   - Accept positional args: `id`, `step_index`, `errors`, `warnings`, `info`, `decision`, `summary`
+   - Parse the optional `--rerun` flag and `--details-file <path>` from the remaining `$@`
+   - Validate `step_index` is a non-negative integer (reuse the guard pattern from `cmd_record_model_selection`)
+   - Validate `errors`, `warnings`, `info` are non-negative integers
+   - Validate `decision` is one of: `advanced`, `auto-advanced`, `user-advanced`, `auto-fixed`, `paused`
+   - Call `validate_state_file` to load the state file path
+   - Perform a bounds check: if `step_index >= length(.steps)`, emit to stderr `Error: stepIndex {N} out of bounds for workflow {ID} (steps length: {M}).` and exit non-zero without writing the file
+   - Determine the target field name: `findings` (default) or `rerunFindings` (when `--rerun` is present)
+   - Build the base findings object using `jq --argjson` for numeric fields and `--arg` for string fields:
+     ```json
+     { "errors": N, "warnings": N, "info": N, "decision": "...", "summary": "..." }
+     ```
+   - When `--details-file` is provided **and** `decision == "auto-advanced"`: read the file, validate it contains a JSON array (`jq -e '. | arrays' <path>`), and merge it as the `details` field. If the file is missing or not a valid JSON array, log `[warn] Could not read details file — recording counts only.` to stderr and write the findings object without `details`.
+   - When `--details-file` is provided but `decision != "auto-advanced"`: silently ignore the file (do not write `details`).
+   - Write the findings object to `steps[stepIndex].findings` or `steps[stepIndex].rerunFindings` using a `jq` expression of the form:
+     ```bash
+     jq --argjson idx "$step_index" --argjson obj "$findings_json" \
+       ".steps[$idx].${field_name} = \$obj" "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+     ```
+   - Print the updated state to stdout (consistent with other mutating subcommands)
+
+3. **Wire `record-findings` into the `case` dispatch block** (before the `*)` fallthrough, after `clear-gate`):
+   ```bash
+   record-findings)
+     [[ $# -ge 7 ]] || { echo "Error: record-findings requires <ID> <stepIndex> <errors> <warnings> <info> <decision> <summary> [--rerun] [--details-file <path>]" >&2; exit 1; }
+     cmd_record_findings "$@"
+     ;;
+   ```
+
+4. **Write unit tests** in `scripts/__tests__/workflow-state.test.ts` under a new `describe('record-findings', ...)` block. Cover all eight scenarios from the requirements testing section:
+   - `record-findings` writes the correct JSON structure (`errors`, `warnings`, `info`, `decision`, `summary` fields on the step entry) for a valid `stepIndex`
+   - `record-findings --rerun` writes to `rerunFindings` without overwriting an existing `findings` field
+   - Summary containing shell-special characters (quotes, `$`, backticks, parentheses) is stored verbatim
+   - `--details-file` with `decision "auto-advanced"` includes the `details` array in the written object
+   - `--details-file` with a non-`auto-advanced` decision omits `details` from the written object
+   - `--details-file` pointing to a file with invalid JSON logs the warning and writes without `details`
+   - `--details-file` pointing to a non-existent file logs the warning and writes without `details`
+   - `stepIndex` equal to the length of the `steps` array (out of bounds) exits non-zero and does not modify the state file
+   - `status` subcommand returns findings data when present and works normally when `findings` fields are absent (backwards-compatibility assertion)
+
+   Each test follows the pattern established by existing `record-model-selection` tests: `run('init ... feature')`, then `run('record-findings ... ')`, then `readState()` to assert on the written JSON.
+
+#### Deliverables
+
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` — `usage()` entry, `cmd_record_findings()` implementation, `case` dispatch entry
+- [x] `scripts/__tests__/workflow-state.test.ts` — `describe('record-findings', ...)` block with nine test cases
+
+---
+
+### Phase 2: Orchestrator Integration in `SKILL.md`
+**Feature:** [FEAT-016](../features/FEAT-016-persist-review-findings.md) | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
+**Status:** Pending
+
+#### Rationale
+
+- Depends on Phase 1: the `record-findings` subcommand must exist before the SKILL.md prose instructs the orchestrator to call it. A reader following the SKILL.md instructions would otherwise be calling a nonexistent subcommand.
+- All six integration points (FR-5 items 1–6) live within the existing "Reviewing-Requirements Findings Handling" section. They are additive insertions — the Decision Flow and Applying Auto-Fixes prose from FEAT-015 are preserved exactly; only `record-findings` calls and the FR-7 parsing instructions are added.
+- Grouping all SKILL.md changes into one phase makes the diff reviewable as a unit and avoids partial states where some decision branches record findings and others do not.
+- The FR-7 parsing specification (how to extract individual findings from subagent output for `auto-advanced` decisions) is detailed enough to warrant its own subsection rather than being scattered across the six integration points.
+
+#### Implementation Steps
+
+1. **Add a "Persisting Findings" subsection** immediately after the `#### Applying Auto-Fixes` subsection and before the `### Chain-Specific Step Details` heading. This subsection consolidates the FR-5 call-site table and the FR-7 parsing procedure so neither needs to be repeated at every integration point in the Decision Flow prose:
+
+   Structure:
+   ```
+   #### Persisting Findings
+
+   At every reviewing-requirements decision point, call `record-findings` **before** `advance` or `pause` to persist the findings in the workflow state file. The call must always precede the state-transition call so that findings survive even if the transition call fails or the process exits.
+
+   ##### Decision-to-Call Mapping
+
+   | Decision taken | `record-findings` invocation |
+   |---|---|
+   | Zero findings → auto-advance | `record-findings {ID} {stepIndex} 0 0 0 advanced "No issues found"` |
+   | Warnings/info only → auto-advance (FEAT-015 gate) | `record-findings {ID} {stepIndex} 0 {W} {I} auto-advanced "{summary}" --details-file {tmp}` |
+   | Warnings/info only → user confirmed | `record-findings {ID} {stepIndex} 0 {W} {I} user-advanced "{summary}"` |
+   | Warnings/info only → user declined | `record-findings {ID} {stepIndex} 0 {W} {I} paused "{summary}"` |
+   | Errors present → user chose "Apply fixes" | `record-findings {ID} {stepIndex} {E} {W} {I} auto-fixed "{summary}"` |
+   | Errors present → user chose "Pause" | `record-findings {ID} {stepIndex} {E} {W} {I} paused "{summary}"` |
+   | Re-run after auto-fix (any outcome) | `record-findings {ID} {stepIndex} {E2} {W2} {I2} {rerun-decision} "{rerun-summary}" --rerun` |
+   | Re-run after auto-fix → auto-advanced | (same as above plus `--details-file {tmp}`) |
+
+   Notes:
+   - `{stepIndex}` is the zero-based index in the `steps` array for the current reviewing-requirements step. Use the chain-step-to-index table: feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6.
+   - When the subagent returns `"No issues found"` or `Found **0 errors**, **0 warnings**, **0 info**`, normalize to `"No issues found"` as the canonical summary.
+   - The `{summary}` must be passed as a single shell-quoted token. Use single quotes around the summary string to handle embedded special characters.
+
+   ##### Parsing Individual Findings for `auto-advanced` Decisions
+
+   When `decision` is `auto-advanced`, parse individual findings from the subagent return text to build the `--details-file` argument:
+
+   1. Scan the subagent return text for lines matching: `**[{W|I}{N}] {category} — {description}**` (or the unbolded variant). The separator is an em dash (`—`, U+2014); accept ASCII double-hyphen (`--`) as a fallback. Map prefix letters: `W` → `"warning"`, `I` → `"info"`.
+   2. For each match, extract:
+      - `id` — severity+number token (e.g., `"W1"`, `"I3"`)
+      - `severity` — mapped from prefix letter
+      - `category` — text between `]` and `—`, trimmed
+      - `description` — text after `—` to end of line, trimmed and stripped of trailing bold markers
+   3. Write the resulting JSON array to `/tmp/findings-{ID}-{stepIndex}.json`
+   4. Pass `--details-file /tmp/findings-{ID}-{stepIndex}.json` to `record-findings`
+   5. Remove the temp file after `record-findings` returns
+
+   If no individual findings can be parsed despite non-zero counts, write `[]` and log: `[warn] Could not parse individual findings from reviewing-requirements output — recording counts only.`
+   ```
+
+2. **Add `record-findings` calls into the Decision Flow subsection** at each of the six integration points. Integrate them as inline bash blocks immediately before each `advance` or `pause` call. The Decision Flow prose structure (items 1, 2, 3) from FEAT-015 is preserved; `record-findings` calls are insertions, not replacements:
+
+   - **Item 1 (Zero findings)**: insert `${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh record-findings {ID} {stepIndex} 0 0 0 advanced "No issues found"` before the `advance` call.
+   - **Item 2, auto-advance branch**: insert the FR-7 parsing procedure inline (brief reference to the "Parsing Individual Findings" subsection), then insert the `record-findings ... auto-advanced ... --details-file {tmp}` call before `advance`.
+   - **Item 2, prompt branch (user confirms)**: insert `record-findings ... user-advanced ...` before `advance`.
+   - **Item 2, prompt branch (user declines)**: insert `record-findings ... paused ...` before `pause`.
+   - **Item 3, "Apply fixes" branch**: insert `record-findings ... auto-fixed ...` at the decision point (before beginning fix application). The re-run's `record-findings --rerun` call is added in the Applying Auto-Fixes section.
+   - **Item 3, "Pause" branch**: insert `record-findings ... paused ...` before `pause`.
+
+3. **Add `record-findings --rerun` calls into the Applying Auto-Fixes subsection** at each re-run outcome branch in step 4. The "do not apply further edits" rule and the three outcome branches (zero errors, warnings/info only, errors) are preserved from FEAT-015; `record-findings --rerun` calls are inserted before each `clear-gate`/`advance`/`pause` call:
+
+   - Zero errors re-run outcome: insert `record-findings {ID} {stepIndex} 0 0 0 advanced "{rerun-summary}" --rerun` before `clear-gate`.
+   - Warnings/info only re-run outcome: run the FR-7 parsing procedure; insert `record-findings {ID} {stepIndex} 0 {W2} {I2} auto-advanced "{rerun-summary}" --rerun --details-file {tmp}` before `clear-gate`.
+   - Errors re-run outcome: insert `record-findings {ID} {stepIndex} {E2} {W2} {I2} paused "{rerun-summary}" --rerun` before `pause`.
+
+4. **Add a note to the Parsing Findings subsection** clarifying that the count-extraction regex must anchor on the `Found **N errors**` substring (not the line start) to handle the test-plan and code-review mode prefixes (e.g., `"Test-plan reconciliation for {ID}: Found **N errors**..."`).
+
+5. **Verify the edit** by reading lines 248–340 of the updated SKILL.md and confirming:
+   - Every decision branch in the Decision Flow has a `record-findings` call placed before its `advance` or `pause` call
+   - The `--rerun` calls appear in Applying Auto-Fixes before the corresponding `clear-gate`/`pause` calls
+   - The FEAT-015 auto-advance gate logic (`type` + `complexity` reads) is unchanged
+   - The gate (`set-gate` / `clear-gate`) calls are still present at the correct positions
+   - The skipped-step paths (CHORE-031 `advance` without fork) have no `record-findings` call
+   - Step index values in the prose examples match the chain-step-to-index table
+
+#### Deliverables
+
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — "Persisting Findings" subsection (including decision-to-call table and FR-7 parsing procedure), `record-findings` calls in Decision Flow items 1–3, `record-findings --rerun` calls in Applying Auto-Fixes step 4
+
+---
+
+## Shared Infrastructure
+
+No new shared utilities are introduced. `jq` is already a declared dependency of `workflow-state.sh`. Temp file paths follow the existing `/tmp/` convention used elsewhere in orchestrator prose.
+
+## Testing Strategy
+
+### Unit Tests (Phase 1)
+
+Shell script tests live in `scripts/__tests__/workflow-state.test.ts` and run via the existing vitest harness with `fileParallelism: false`. Each test runs the actual `workflow-state.sh` bash script in a fresh `tmpdir` working directory (same pattern as the FEAT-014 tests). The nine test cases cover all edge paths for `record-findings` — correct writes, `--rerun` isolation, shell-special-character safety, conditional `details` inclusion, error recovery for bad `--details-file`, and out-of-bounds `stepIndex`.
+
+### Manual Testing (Phase 2)
+
+The requirements manual-testing matrix covers five scenarios:
+
+| Scenario | Verification |
+|---|---|
+| Bug/chore workflow, zero findings | `findings.decision == "advanced"` on the step entry |
+| Bug/chore workflow (complexity ≤ medium), warnings-only | `findings.decision == "auto-advanced"` with populated `details` array |
+| Feature workflow, warnings-only, user confirms | `findings.decision == "user-advanced"` without `details` |
+| Workflow with errors → apply fixes → re-run succeeds | `findings.decision == "auto-fixed"` and `rerunFindings.decision == "advanced"` |
+| Workflow with errors → apply fixes → re-run still has errors | `findings.decision == "auto-fixed"` and `rerunFindings.decision == "paused"` |
+| Workflow with errors → user pauses | `findings.decision == "paused"` without `rerunFindings` |
+| Completed workflow | All non-skipped reviewing-requirements steps have `findings` |
+
+Inspection command:
+```bash
+jq '[.steps[] | select(.skill == "reviewing-requirements") | {name, findings, rerunFindings}]' \
+  ".sdlc/workflows/{ID}.json"
+```
+
+## Dependencies and Prerequisites
+
+- **FEAT-015 / #139** — The `auto-advanced` decision value and the FEAT-015 auto-advance gate (item 2's chain-type/complexity check) must be in place before Phase 2 integration calls can reference `auto-advanced` paths. FEAT-015 is already merged.
+- **`jq`** — Already a declared dependency; no version requirement beyond what is currently in use.
+
+## Risk Assessment
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Shell-quoting issue with `summary` arg containing embedded quotes | Medium | Low | Use `--arg` (not `--argjson`) for all string fields in `jq`; single-quote the summary token at every call site in SKILL.md prose |
+| `record-findings` call placed after `advance`/`pause` instead of before | Medium | Low | NFR-3 states the ordering requirement explicitly; Phase 2 verification step confirms ordering before the phase is marked complete |
+| `details` written for non-`auto-advanced` decisions due to mis-read flag logic | Low | Low | Unit test "non-`auto-advanced` decision ignores `--details-file`" catches this directly |
+| FR-7 parsing fails for all findings despite non-zero counts | Low | Low | Fallback to empty `[]` with a warn log keeps the write non-fatal; counts from the summary line remain authoritative |
+| Out-of-bounds `stepIndex` silently writes garbage due to jq array expansion | Medium | Low | Explicit length check in `cmd_record_findings` before any `jq` write; unit test asserts non-zero exit and no file mutation |
+
+## Success Criteria
+
+- [ ] After every non-skipped reviewing-requirements step, the state file contains a `findings` object on the step entry with `errors`, `warnings`, `info`, `decision`, and `summary` fields
+- [ ] Auto-advanced steps include a `findings` record with a populated `details` array
+- [ ] Non-auto-advanced steps include a `findings` record without a `details` field
+- [ ] When auto-fixes are applied and a re-run occurs, both `findings` and `rerunFindings` are present on the step entry
+- [ ] When `rerunFindings.decision` is `"auto-advanced"`, `rerunFindings` includes a `details` array
+- [ ] Skipped steps (CHORE-031 low-complexity) have no `findings` field
+- [ ] Existing workflow state files without `findings` fields remain valid (backwards-compatible; `status` subcommand returns full state including absence of these fields without error)
+- [ ] The Decision Flow logic is unchanged — `record-findings` is additive and does not influence advance/pause decisions
+
+## Code Organization
+
+All changes are confined to two files:
+
+```
+plugins/lwndev-sdlc/skills/orchestrating-workflows/
+├── scripts/
+│   └── workflow-state.sh            ← Phase 1: usage(), cmd_record_findings(), case dispatch
+└── SKILL.md                         ← Phase 2: "Persisting Findings" subsection + call sites
+
+scripts/__tests__/
+└── workflow-state.test.ts           ← Phase 1: describe('record-findings', ...) block
+```
+
+No new files are created. No other skills, state-file schemas at the top level, or subcommand behaviors are modified.

--- a/requirements/implementation/FEAT-016-persist-review-findings.md
+++ b/requirements/implementation/FEAT-016-persist-review-findings.md
@@ -89,7 +89,7 @@ The implementation has a natural dependency order: `workflow-state.sh` must expo
 
 ### Phase 2: Orchestrator Integration in `SKILL.md`
 **Feature:** [FEAT-016](../features/FEAT-016-persist-review-findings.md) | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
-**Status:** Pending
+**Status:** 🔄 In Progress
 
 #### Rationale
 

--- a/requirements/implementation/FEAT-016-persist-review-findings.md
+++ b/requirements/implementation/FEAT-016-persist-review-findings.md
@@ -89,7 +89,7 @@ The implementation has a natural dependency order: `workflow-state.sh` must expo
 
 ### Phase 2: Orchestrator Integration in `SKILL.md`
 **Feature:** [FEAT-016](../features/FEAT-016-persist-review-findings.md) | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
-**Status:** 🔄 In Progress
+**Status:** ✅ Complete
 
 #### Rationale
 
@@ -170,7 +170,7 @@ The implementation has a natural dependency order: `workflow-state.sh` must expo
 
 #### Deliverables
 
-- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — "Persisting Findings" subsection (including decision-to-call table and FR-7 parsing procedure), `record-findings` calls in Decision Flow items 1–3, `record-findings --rerun` calls in Applying Auto-Fixes step 4
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — "Persisting Findings" subsection (including decision-to-call table and FR-7 parsing procedure), `record-findings` calls in Decision Flow items 1–3, `record-findings --rerun` calls in Applying Auto-Fixes step 4
 
 ---
 

--- a/requirements/implementation/FEAT-016-persist-review-findings.md
+++ b/requirements/implementation/FEAT-016-persist-review-findings.md
@@ -20,7 +20,7 @@ The implementation has a natural dependency order: `workflow-state.sh` must expo
 
 ### Phase 1: `record-findings` Subcommand in `workflow-state.sh`
 **Feature:** [FEAT-016](../features/FEAT-016-persist-review-findings.md) | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
-**Status:** 🔄 In Progress
+**Status:** ✅ Complete
 
 #### Rationale
 

--- a/requirements/implementation/FEAT-016-persist-review-findings.md
+++ b/requirements/implementation/FEAT-016-persist-review-findings.md
@@ -10,7 +10,7 @@ The change is scoped to two artifacts: a new `record-findings` subcommand in `wo
 
 | Feature ID | GitHub Issue | Feature Document | Priority | Complexity | Status |
 |------------|--------------|------------------|----------|------------|--------|
-| FEAT-016 | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145) | [FEAT-016-persist-review-findings.md](../features/FEAT-016-persist-review-findings.md) | Medium | Medium | Pending |
+| FEAT-016 | [#145](https://github.com/lwndev/lwndev-marketplace/issues/145) | [FEAT-016-persist-review-findings.md](../features/FEAT-016-persist-review-findings.md) | Medium | Medium | ✅ Complete |
 
 ## Recommended Build Sequence
 

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -71,7 +71,7 @@ describe('orchestrating-workflows skill', () => {
       // All references should use ${CLAUDE_SKILL_DIR}/ prefix
       const prefixedRefs = body.match(/\$\{CLAUDE_SKILL_DIR\}\/scripts\/workflow-state\.sh/g);
       expect(prefixedRefs).not.toBeNull();
-      expect(prefixedRefs!.length).toBe(23);
+      expect(prefixedRefs!.length).toBe(37);
     });
 
     it('should include "When to Use This Skill" section', () => {

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -1173,6 +1173,148 @@ describe('workflow-state.sh', () => {
       });
     });
 
+    describe('record-findings', () => {
+      it('writes the correct JSON structure for a valid stepIndex', () => {
+        runJSON('init FEAT-001 feature');
+        const state = runJSON('record-findings FEAT-001 1 3 2 1 advanced "No issues found"');
+        const steps = state.steps as Array<Record<string, unknown>>;
+        expect(steps[1].findings).toEqual({
+          errors: 3,
+          warnings: 2,
+          info: 1,
+          decision: 'advanced',
+          summary: 'No issues found',
+        });
+        // Numeric fields are numbers, not strings.
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(typeof findings.errors).toBe('number');
+        expect(typeof findings.warnings).toBe('number');
+        expect(typeof findings.info).toBe('number');
+      });
+
+      it('--rerun writes to rerunFindings without overwriting an existing findings field', () => {
+        runJSON('init FEAT-001 feature');
+        runJSON('record-findings FEAT-001 1 0 2 1 auto-advanced "Warnings found"');
+        const state = runJSON('record-findings FEAT-001 1 0 0 0 advanced "Clean on rerun" --rerun');
+        const steps = state.steps as Array<Record<string, unknown>>;
+        // Original findings must be preserved.
+        expect(steps[1].findings).toMatchObject({ decision: 'auto-advanced' });
+        // rerunFindings must be written.
+        expect(steps[1].rerunFindings).toMatchObject({
+          decision: 'advanced',
+          summary: 'Clean on rerun',
+        });
+      });
+
+      it('stores a summary containing shell-special characters verbatim', () => {
+        runJSON('init FEAT-001 feature');
+        const specialSummary = 'Found: $HOME `echo hi` (parens) "quotes" \'single\'';
+        // Pass the summary as a single shell-quoted argument via execSync.
+        const state = JSON.parse(
+          execSync(
+            `bash "${SCRIPT}" record-findings FEAT-001 1 0 1 0 paused '${specialSummary.replace(/'/g, "'\\''")}'`,
+            { cwd: testDir, encoding: 'utf-8' }
+          )
+        ) as Record<string, unknown>;
+        const steps = state.steps as Array<Record<string, unknown>>;
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(findings.summary).toBe(specialSummary);
+      });
+
+      it('--details-file with decision "auto-advanced" includes the details array', () => {
+        runJSON('init FEAT-001 feature');
+        const detailsFile = join(testDir, 'details.json');
+        const detailsArray = [
+          { id: 'W1', severity: 'warning', category: 'Style', description: 'Missing semicolon' },
+          { id: 'I1', severity: 'info', category: 'Docs', description: 'Consider adding example' },
+        ];
+        writeFileSync(detailsFile, JSON.stringify(detailsArray));
+        const state = runJSON(
+          `record-findings FEAT-001 1 0 1 1 auto-advanced "Warnings only" --details-file ${detailsFile}`
+        );
+        const steps = state.steps as Array<Record<string, unknown>>;
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(findings.decision).toBe('auto-advanced');
+        expect(Array.isArray(findings.details)).toBe(true);
+        expect(findings.details).toEqual(detailsArray);
+      });
+
+      it('--details-file with a non-auto-advanced decision omits details from the written object', () => {
+        runJSON('init FEAT-001 feature');
+        const detailsFile = join(testDir, 'details.json');
+        writeFileSync(
+          detailsFile,
+          JSON.stringify([{ id: 'W1', severity: 'warning', category: 'Style', description: 'x' }])
+        );
+        const state = runJSON(
+          `record-findings FEAT-001 1 0 1 0 user-advanced "User confirmed" --details-file ${detailsFile}`
+        );
+        const steps = state.steps as Array<Record<string, unknown>>;
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(findings.decision).toBe('user-advanced');
+        expect(Object.prototype.hasOwnProperty.call(findings, 'details')).toBe(false);
+      });
+
+      it('--details-file pointing to invalid JSON logs warning and writes without details', () => {
+        runJSON('init FEAT-001 feature');
+        const badFile = join(testDir, 'bad.json');
+        writeFileSync(badFile, 'not valid json {{');
+        // Should succeed (exit 0) but log warning to stderr.
+        const output = execSync(
+          `bash "${SCRIPT}" record-findings FEAT-001 1 0 1 0 auto-advanced "Warnings" --details-file ${badFile}`,
+          { cwd: testDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        const state = JSON.parse(output) as Record<string, unknown>;
+        const steps = state.steps as Array<Record<string, unknown>>;
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(findings.decision).toBe('auto-advanced');
+        expect(Object.prototype.hasOwnProperty.call(findings, 'details')).toBe(false);
+      });
+
+      it('--details-file pointing to a non-existent file logs warning and writes without details', () => {
+        runJSON('init FEAT-001 feature');
+        const missingFile = join(testDir, 'missing.json');
+        const output = execSync(
+          `bash "${SCRIPT}" record-findings FEAT-001 1 0 1 0 auto-advanced "Warnings" --details-file ${missingFile} 2>&1 || true`,
+          { cwd: testDir, encoding: 'utf-8', shell: '/bin/bash' }
+        );
+        // Should contain the warning.
+        expect(output).toContain('[warn] Could not read details file');
+        // State file must still be updated without details.
+        const stateAfter = readState('FEAT-001');
+        const steps = stateAfter.steps as Array<Record<string, unknown>>;
+        const findings = steps[1].findings as Record<string, unknown>;
+        expect(findings.decision).toBe('auto-advanced');
+        expect(Object.prototype.hasOwnProperty.call(findings, 'details')).toBe(false);
+      });
+
+      it('stepIndex equal to steps.length (out of bounds) exits non-zero and does not modify the state file', () => {
+        runJSON('init FEAT-001 feature');
+        // Feature workflow has 6 initial steps; index 6 is out of bounds.
+        const before = readState('FEAT-001');
+        const err = run('record-findings FEAT-001 6 0 0 0 advanced "test"', { expectError: true });
+        expect(err).toContain('out of bounds');
+        const after = readState('FEAT-001');
+        expect(JSON.stringify(after)).toBe(JSON.stringify(before));
+      });
+
+      it('status subcommand returns findings data when present and works normally when absent', () => {
+        runJSON('init FEAT-001 feature');
+        // Without findings: status should work normally.
+        const stateWithout = runJSON('status FEAT-001');
+        const stepsWithout = stateWithout.steps as Array<Record<string, unknown>>;
+        expect(Object.prototype.hasOwnProperty.call(stepsWithout[1], 'findings')).toBe(false);
+
+        // After recording findings: status should include the findings field.
+        runJSON('record-findings FEAT-001 1 0 0 0 advanced "No issues found"');
+        const stateWith = runJSON('status FEAT-001');
+        const stepsWith = stateWith.steps as Array<Record<string, unknown>>;
+        expect(Object.prototype.hasOwnProperty.call(stepsWith[1], 'findings')).toBe(true);
+        const findings = stepsWith[1].findings as Record<string, unknown>;
+        expect(findings.decision).toBe('advanced');
+      });
+    });
+
     describe('classifier (FEAT-014 Phase 2)', () => {
       // --- chore signal extractor tests ---
       describe('chore classifier', () => {

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -1261,11 +1261,14 @@ describe('workflow-state.sh', () => {
         writeFileSync(badFile, 'not valid json {{');
         // Should succeed (exit 0) but log warning to stderr.
         const output = execSync(
-          `bash "${SCRIPT}" record-findings FEAT-001 1 0 1 0 auto-advanced "Warnings" --details-file ${badFile}`,
-          { cwd: testDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+          `bash "${SCRIPT}" record-findings FEAT-001 1 0 1 0 auto-advanced "Warnings" --details-file ${badFile} 2>&1`,
+          { cwd: testDir, encoding: 'utf-8' }
         );
-        const state = JSON.parse(output) as Record<string, unknown>;
-        const steps = state.steps as Array<Record<string, unknown>>;
+        // Should contain the warning on stderr (merged into stdout via 2>&1).
+        expect(output).toContain('[warn] Could not read details file');
+        // State file must still be updated without details.
+        const stateAfter = readState('FEAT-001');
+        const steps = stateAfter.steps as Array<Record<string, unknown>>;
         const findings = steps[1].findings as Record<string, unknown>;
         expect(findings.decision).toBe('auto-advanced');
         expect(Object.prototype.hasOwnProperty.call(findings, 'details')).toBe(false);


### PR DESCRIPTION
## Summary

This PR implements findings persistence for the reviewing-requirements workflow step:

1. **record-findings subcommand** - New subcommand that reads reviewing-requirements findings from JSON output and records them in workflow state files
2. **orchestrator integration** - SKILL.md instructions for orchestrating workflows now include the record-findings subcommand as part of the workflow state persistence

This ensures that reviewing-requirements results (findings, recommendations, reconciliation notes) are captured and maintained in the workflow state files throughout the SDLC lifecycle.

## Closes

Closes #145

## Key Changes

- Adds findings persistence mechanism to workflow state
- Enables reviewing-requirements results to be recorded across workflow phases
- Maintains workflow state integrity throughout the SDLC process