### PR TITLE
release(lwndev-sdlc): v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.9.1"
+      "version": "1.10.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.10.0] - 2026-04-18
+
+### Features
+
+- **FEAT-016:** Persist reviewing-requirements findings in workflow state ([#145](https://github.com/lwndev/lwndev-marketplace/issues/145)). Adds a `record-findings` subcommand to `workflow-state.sh` and integrates it at every decision point in the orchestrator's findings handling flow, so severity counts, decisions, and individual finding details are durably recorded in the state file after each reviewing-requirements step.
+
+[1.10.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.9.1...lwndev-sdlc@1.10.0
+
 ## [1.9.1] - 2026-04-12
 
 ### Documentation

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.9.1 | **Released:** 2026-04-12
+**Version:** 1.10.0 | **Released:** 2026-04-18
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

- Bump lwndev-sdlc plugin from v1.9.1 to v1.10.0

### Changes

- **FEAT-016:** Persist reviewing-requirements findings in workflow state (#145). Adds `record-findings` subcommand to `workflow-state.sh` and integrates at every decision point in the orchestrator's findings handling flow.

### Files changed

- `plugin.json` — version bump
- `marketplace.json` — version bump
- `CHANGELOG.md` — new 1.10.0 entry
- `README.md` — version/date update