### PR TITLE
chore(configuration): fix skill permission prompts

### DIFF
--- a/plugins/lwndev-sdlc/skills/executing-bug-fixes/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/executing-bug-fixes/SKILL.md
@@ -8,7 +8,6 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-  - Agent
 argument-hint: <bug-id>
 ---
 

--- a/plugins/lwndev-sdlc/skills/executing-chores/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/executing-chores/SKILL.md
@@ -8,7 +8,6 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-  - Agent
 argument-hint: <chore-id>
 ---
 

--- a/plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md
@@ -4,7 +4,6 @@ description: Merges the current PR, checks out main, fetches, and pulls — redu
 allowed-tools:
   - Bash
   - Read
-  - Glob
 ---
 
 # Finalizing Workflow

--- a/plugins/lwndev-sdlc/skills/implementing-plan-phases/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/implementing-plan-phases/SKILL.md
@@ -8,7 +8,6 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-  - Agent
 argument-hint: "<plan-file> [phase-number]"
 ---
 

--- a/qa/test-plans/QA-plan-CHORE-033.md
+++ b/qa/test-plans/QA-plan-CHORE-033.md
@@ -1,0 +1,81 @@
+# QA Test Plan: Fix Skill Permission Prompts
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Plan ID** | QA-plan-CHORE-033 |
+| **Requirement Type** | CHORE |
+| **Requirement ID** | CHORE-033 |
+| **Source Documents** | `requirements/chores/CHORE-033-fix-skill-permission-prompts.md` |
+| **Date Created** | 2026-04-18 |
+
+## Existing Test Verification
+
+Tests that already exist and must continue to pass (regression baseline):
+
+| Test File | Description | Status |
+|-----------|-------------|--------|
+| `scripts/__tests__/build.test.ts` | Plugin validation pipeline — ensures `validate()` still accepts the modified SKILL.md files with their trimmed `allowed-tools` lists | PASS |
+| `scripts/__tests__/*.test.ts` (all) | Full `vitest` suite — must continue to pass (`fileParallelism: false` per `vitest.config.ts`) | PASS |
+
+## New Test Analysis
+
+No new test files are needed. This chore only edits configuration/settings and frontmatter metadata — existing validation coverage is sufficient.
+
+| Test Description | Target File(s) | Requirement Ref | Priority | Status |
+|-----------------|----------------|-----------------|----------|--------|
+| — | — | — | — | — |
+
+## Coverage Gap Analysis
+
+| Gap Description | Affected Code | Requirement Ref | Recommendation |
+|----------------|---------------|-----------------|----------------|
+| AC8 (permission-prompt absence) has no automated test. The Skill-invocation allowlist matching happens inside the Claude Code runtime, not in repo code. | N/A | AC8 | Manual verification: open a fresh Claude Code session in this repo, invoke each skill (or at minimum the two newly-added ones plus one previously-problematic one) via `/<plugin>:<skill-name>`, confirm no `Skill(...)` permission prompt appears. |
+| AC2 (Bash syntax migration) has no automated validation of pattern matching — the runtime is the only authority. | `.claude/settings.local.json` | AC2 | Manual verification: after the migration, attempt a representative `Bash(cmd ...)` command (e.g., `gh issue list`) in a fresh session and confirm it auto-approves via the migrated `Bash(gh issue *)` rule. |
+
+## Code Path Verification
+
+One entry per acceptance criterion (CHORE convention):
+
+| Requirement | Description | Expected Code Path | Verification Method | Status |
+|-------------|-------------|-------------------|-------------------|--------|
+| AC1 | `.claude/settings.local.json` contains `Skill(lwndev-sdlc:orchestrating-workflows)` and `Skill(lwndev-sdlc:managing-work-items)` in `permissions.allow` | `.claude/settings.local.json` → `permissions.allow[]` | `jq -r '.permissions.allow[]' .claude/settings.local.json \| grep -E 'Skill\(lwndev-sdlc:(orchestrating-workflows\|managing-work-items)\)'` must return both lines | PASS |
+| AC2 | All command-prefix `Bash(<cmd>:*)` entries migrated to `Bash(<cmd> *)` in settings.local.json (scope: simple command-prefix entries at the top of the file such as `Bash(gh issue:*)`, `Bash(git commit:*)`; path-style entries like `Bash(./scripts/workflow-state.sh init:*)` are OUT of scope and must remain unchanged — see Notes in chore doc for rationale) | `.claude/settings.local.json` → `permissions.allow[]` | `jq -r '.permissions.allow[]' .claude/settings.local.json \| grep -E '^Bash\((gh\|git\|npm\|node\|jq)[^/]*:\*\)$'` must return zero rows; equivalent space-syntax rules must exist | PASS |
+| AC3 | Stale `Skill(implementing-plan-phases)` (no `lwndev-sdlc:` prefix) is removed; the prefixed variant `Skill(lwndev-sdlc:implementing-plan-phases)` is retained | `.claude/settings.local.json` → `permissions.allow[]` | `jq -r '.permissions.allow[]' .claude/settings.local.json \| grep -x 'Skill(implementing-plan-phases)'` must return zero rows; `grep -x 'Skill(lwndev-sdlc:implementing-plan-phases)'` must return one row | PASS |
+| AC4 | `Agent` removed from `allowed-tools` in `executing-bug-fixes`, `executing-chores`, and `implementing-plan-phases` SKILL.md files | `plugins/lwndev-sdlc/skills/{executing-bug-fixes,executing-chores,implementing-plan-phases}/SKILL.md` → frontmatter `allowed-tools` block | For each file, read the YAML frontmatter and confirm `- Agent` does not appear between `allowed-tools:` and the next top-level key | PASS |
+| AC5 | `Glob` removed from `allowed-tools` in `finalizing-workflow/SKILL.md` | `plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md` → frontmatter `allowed-tools` block | Read frontmatter, confirm `- Glob` is absent from the `allowed-tools` block | PASS |
+| AC6 | `npm run validate` passes | `scripts/build.ts` via the `validate` npm script | Run `npm run validate` from repo root, confirm exit code 0 and no plugin reports errors | PASS |
+| AC7 | `npm test` passes | `scripts/__tests__/*.test.ts` via `vitest` | Run `npm test` from repo root, confirm exit code 0 | PASS |
+| AC8 | No `Skill(...)` permission prompt appears when invoking any of the 13 skills in `plugins/lwndev-sdlc/skills/` in a fresh Claude Code session | Claude Code runtime permission-matching | Manual — open fresh session; at minimum invoke `/lwndev-sdlc:orchestrating-workflows` and `/lwndev-sdlc:managing-work-items` (the two newly allowed) and confirm no `Skill(...)` prompt; spot-check one other skill (e.g., `/lwndev-sdlc:documenting-features`) | SKIP |
+
+## Deliverable Verification
+
+Key output artifacts of this chore:
+
+| Deliverable | Source Phase | Expected Path | Status |
+|-------------|-------------|---------------|--------|
+| Updated permission settings | Implementation | `.claude/settings.local.json` (allow array modified) | PASS |
+| Trimmed SKILL.md frontmatters (×4) | Implementation | `plugins/lwndev-sdlc/skills/{executing-bug-fixes,executing-chores,implementing-plan-phases,finalizing-workflow}/SKILL.md` | PASS |
+| Updated allowed-tools test assertions (×3) | Implementation | `scripts/__tests__/{executing-bug-fixes,executing-chores,implementing-plan-phases}.test.ts` | PASS |
+
+## Scope Boundary Verification
+
+CHORE-specific: confirm no unrelated changes are introduced.
+
+| Boundary | Verification |
+|----------|--------------|
+| No SKILL.md body changes | `git diff plugins/lwndev-sdlc/skills/{executing-bug-fixes,executing-chores,implementing-plan-phases,finalizing-workflow}/SKILL.md` must show only frontmatter `allowed-tools` edits (a single removed line per file). No edits outside the `---` frontmatter block. |
+| No other SKILL.md files modified | `git diff --name-only -- 'plugins/lwndev-sdlc/skills/**/SKILL.md'` must match exactly the 4 files listed in AC4/AC5 |
+| Test file changes limited to the 3 expected files | `git diff --name-only -- 'scripts/**'` must list exactly `scripts/__tests__/{executing-bug-fixes,executing-chores,implementing-plan-phases}.test.ts` — updates to allowed-tools assertions consistent with AC4. `git diff --name-only -- '*.json' ':!.claude/settings.local.json'` must be empty. |
+| Path-style `Bash(...:*)` entries preserved | After AC2 migration, entries like `Bash(./scripts/workflow-state.sh init:*)` and `Bash(/Users/leif/.claude/plugins/cache/...:*)` must remain unchanged (AC2 explicitly scopes them out) |
+| `orchestrating-workflows/SKILL.md` untouched | `git diff plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` must be empty — adding `allowed-tools` is explicitly out of scope per chore doc Notes |
+
+## Plan Completeness Checklist
+
+- [x] All existing tests pass (regression baseline)
+- [x] All FR-N / RC-N / AC entries have corresponding test plan entries
+- [x] Coverage gaps are identified with recommendations
+- [x] Code paths trace from requirements to implementation
+- [x] Phase deliverables are accounted for (if applicable)
+- [x] New test recommendations are actionable and prioritized

--- a/qa/test-results/QA-results-CHORE-033.md
+++ b/qa/test-results/QA-results-CHORE-033.md
@@ -1,0 +1,86 @@
+# QA Results: Fix Skill Permission Prompts
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Results ID** | QA-results-CHORE-033 |
+| **Requirement Type** | CHORE |
+| **Requirement ID** | CHORE-033 |
+| **Source Test Plan** | `qa/test-plans/QA-plan-CHORE-033.md` |
+| **Date** | 2026-04-18 |
+| **Verdict** | PASS (AC8 deferred to manual post-merge verification) |
+| **Verification Iterations** | 2 |
+
+## Per-Entry Verification Results
+
+| # | Test Description | Target File(s) | Requirement Ref | Result | Notes |
+|---|-----------------|----------------|-----------------|--------|-------|
+| 1 | `build.test.ts` passes | `scripts/__tests__/build.test.ts` | Existing Test | PASS | 12/12 tests pass |
+| 2 | Full vitest suite passes | `scripts/__tests__/*.test.ts` | Existing Test | PASS | 752/752 tests, 24 files, 0 failures |
+| 3 | Two new Skill rules present in project settings | `.claude/settings.local.json` | AC1 | PASS | `jq` grep returned both `Skill(lwndev-sdlc:orchestrating-workflows)` and `Skill(lwndev-sdlc:managing-work-items)` after settings restore |
+| 4 | Colon-style `Bash(<cmd>:*)` migrated to space syntax | `.claude/settings.local.json` | AC2 | PASS | Zero colon-style matches; space-syntax equivalents (`Bash(gh issue *)`, `Bash(git commit *)`, etc.) present |
+| 5 | Stale `Skill(implementing-plan-phases)` removed; prefixed variant retained | `.claude/settings.local.json` | AC3 | PASS | Unprefixed absent; prefixed present |
+| 6 | `Agent` absent from frontmatter | `plugins/lwndev-sdlc/skills/{executing-bug-fixes,executing-chores,implementing-plan-phases}/SKILL.md` | AC4 | PASS | All three frontmatters lack `- Agent`; git diff confirms single-line removals |
+| 7 | `Glob` absent from frontmatter | `plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md` | AC5 | PASS | Frontmatter contains only `- Bash` and `- Read`; git diff confirms `- Glob` removal |
+| 8 | `npm run validate` exits 0 | `scripts/build.ts` | AC6 | PASS | Exit 0; 13/13 skills validated |
+| 9 | `npm test` exits 0 | `scripts/__tests__/*.test.ts` | AC7 | PASS | Exit 0; 752/752 pass |
+| 10 | No `Skill(...)` permission prompt in fresh Claude Code session | Claude Code runtime | AC8 | SKIP | Manual-only verification — requires fresh CLI session. Deferred to post-merge. |
+| 11 | Settings file modified as deliverable | `.claude/settings.local.json` | Deliverable | PASS | Verified post-restore (gitignored file) |
+| 12 | Four SKILL.md frontmatters trimmed | `plugins/lwndev-sdlc/skills/{executing-bug-fixes,executing-chores,implementing-plan-phases,finalizing-workflow}/SKILL.md` | Deliverable | PASS | All four diffs present |
+| 13 | Three test assertion files updated | `scripts/__tests__/{executing-bug-fixes,executing-chores,implementing-plan-phases}.test.ts` | Deliverable (added during reconciliation) | PASS | All three updated from `toContain('- Agent')` to `not.toContain('- Agent')` |
+| 14 | No SKILL.md body changes (frontmatter only) | 4 SKILL.md files | Scope Boundary | PASS | Each diff is single-line removal inside `---` block |
+| 15 | Exactly 4 SKILL.md files modified | `plugins/lwndev-sdlc/skills/**/SKILL.md` | Scope Boundary | PASS | `git diff --name-only` matches the expected 4 files |
+| 16 | `scripts/**` diff limited to 3 expected test files | `scripts/__tests__/*.test.ts` | Scope Boundary | PASS | Exactly the three expected test files changed; no other scripts/ modifications |
+| 17 | `orchestrating-workflows/SKILL.md` untouched | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` | Scope Boundary | PASS | Empty diff |
+
+### Summary
+
+- **Total entries:** 17
+- **Passed:** 16
+- **Failed:** 0
+- **Skipped:** 1 (AC8 — manual-only)
+
+## Test Suite Results
+
+| Metric | Count |
+|--------|-------|
+| **Total Tests** | 752 |
+| **Passed** | 752 |
+| **Failed** | 0 |
+| **Errors** | 0 |
+
+## Issues Found and Fixed
+
+| Entry # | Issue | Resolution | Iteration Fixed |
+|---------|-------|-----------|-----------------|
+| AC1 / AC2 / AC3 | On first verification pass, `.claude/settings.local.json` showed `"allow": []` — the chore's settings changes had not persisted (or had been reset). AC1/AC2/AC3 initially failed. | User restored `.claude/settings.local.json` manually. Re-verification confirmed both new Skill rules present, colon-syntax entries migrated to space syntax, and stale unprefixed Skill entry removed. | Iteration 2 |
+
+## Reconciliation Summary
+
+### Changes Made to Requirements Documents
+
+| Document | Section | Change |
+|----------|---------|--------|
+| `requirements/chores/CHORE-033-fix-skill-permission-prompts.md` | Affected Files | Added three test files (`scripts/__tests__/{executing-bug-fixes,executing-chores,implementing-plan-phases}.test.ts`) that were modified but not originally listed |
+| `requirements/chores/CHORE-033-fix-skill-permission-prompts.md` | Completion › Status | Changed `In Progress` → `Complete (pending manual AC8 verification)` |
+| `qa/test-plans/QA-plan-CHORE-033.md` | Deliverable Verification | Added row for the three updated test assertion files |
+| `qa/test-plans/QA-plan-CHORE-033.md` | Scope Boundary Verification | Rewrote the "No code or test file changes" row — the original wording asserted `scripts/**` diff must be empty, but three test file changes are expected per AC4/AC7. Row now whitelists the three expected files. |
+| `qa/test-plans/QA-plan-CHORE-033.md` | Test statuses across all sections | Updated `PENDING` → `PASS` for all verified entries; `AC8` → `SKIP` (manual-only) |
+
+### Affected Files Updates
+
+| Document | Files Added | Files Removed |
+|----------|------------|---------------|
+| `requirements/chores/CHORE-033-fix-skill-permission-prompts.md` | `scripts/__tests__/executing-bug-fixes.test.ts`, `scripts/__tests__/executing-chores.test.ts`, `scripts/__tests__/implementing-plan-phases.test.ts` | — |
+
+### Acceptance Criteria Modifications
+
+No ACs were modified, added, or descoped. AC8 remains unchecked and unchanged — it is a manual-only verification step that must be performed by the user in a fresh Claude Code session after merge.
+
+## Deviation Notes
+
+| Area | Planned | Actual | Rationale |
+|------|---------|--------|-----------|
+| Test file updates | Not listed in Affected Files | Three `scripts/__tests__/*.test.ts` files updated | Test assertions had to be updated from `toContain('- Agent')` to `not.toContain('- Agent')` to match the SKILL.md frontmatter changes in AC4. Implied by AC7 ("npm test passes") but never listed explicitly. Backported during reconciliation. |
+| Settings persistence | Chore commit claimed to apply settings changes | Settings file found empty at QA time | `.claude/settings.local.json` is gitignored and was observed to be empty at the start of QA verification (reason unknown — possibly reset between commit and QA). User manually restored the file; verification then passed. Documented here so the recurrence is traceable if it happens again. |

--- a/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
+++ b/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
@@ -23,6 +23,9 @@ Add missing `Skill(...)` allow rules for `orchestrating-workflows` and `managing
 - `plugins/lwndev-sdlc/skills/executing-chores/SKILL.md` — remove unused `Agent` from `allowed-tools`
 - `plugins/lwndev-sdlc/skills/implementing-plan-phases/SKILL.md` — remove unused `Agent` from `allowed-tools`
 - `plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md` — remove unused `Glob` from `allowed-tools`
+- `scripts/__tests__/executing-bug-fixes.test.ts` — update allowed-tools assertion to expect `Agent` absent
+- `scripts/__tests__/executing-chores.test.ts` — update allowed-tools assertion to expect `Agent` absent
+- `scripts/__tests__/implementing-plan-phases.test.ts` — update allowed-tools assertion to expect `Agent` absent
 
 ## Acceptance Criteria
 
@@ -37,7 +40,7 @@ Add missing `Skill(...)` allow rules for `orchestrating-workflows` and `managing
 
 ## Completion
 
-**Status:** `In Progress`
+**Status:** `Complete (pending manual AC8 verification)`
 
 **Pull Request:** [#161](https://github.com/lwndev/lwndev-marketplace/pull/161)
 

--- a/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
+++ b/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
@@ -1,0 +1,57 @@
+# Chore: Fix Skill Permission Prompts
+
+## Chore ID
+
+`CHORE-033`
+
+## GitHub Issue
+
+[#80](https://github.com/lwndev/lwndev-marketplace/issues/80)
+
+## Category
+
+`configuration`
+
+## Description
+
+Add missing `Skill(...)` allow rules for `orchestrating-workflows` and `managing-work-items` to `.claude/settings.local.json`, align Bash permission entries with the documented settings.json pattern syntax, and remove unused tool declarations from four SKILL.md frontmatters. The root cause of user-visible permission prompts identified in #80 is missing Skill rules, not `allowed-tools` format — the unused-tool and Bash-syntax changes are opportunistic cleanups in the same area.
+
+## Affected Files
+
+- `.claude/settings.local.json` — add two missing `Skill(...)` rules, migrate `Bash(cmd:*)` entries to `Bash(cmd *)`, remove stale `Skill(implementing-plan-phases)` (no plugin prefix)
+- `plugins/lwndev-sdlc/skills/executing-bug-fixes/SKILL.md` — remove unused `Agent` from `allowed-tools`
+- `plugins/lwndev-sdlc/skills/executing-chores/SKILL.md` — remove unused `Agent` from `allowed-tools`
+- `plugins/lwndev-sdlc/skills/implementing-plan-phases/SKILL.md` — remove unused `Agent` from `allowed-tools`
+- `plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md` — remove unused `Glob` from `allowed-tools`
+
+## Acceptance Criteria
+
+- [x] `.claude/settings.local.json` contains `Skill(lwndev-sdlc:orchestrating-workflows)` and `Skill(lwndev-sdlc:managing-work-items)` in `permissions.allow`
+- [x] All `Bash(<cmd>:*)` entries in `.claude/settings.local.json` that use the colon-separator convention for a command prefix are migrated to `Bash(<cmd> *)` (space-separated) to match the documented settings.json pattern-matching behavior; allowed-tools frontmatter in SKILL.md files is untouched
+- [x] Stale `Skill(implementing-plan-phases)` entry (without the `lwndev-sdlc:` plugin prefix) is removed from `.claude/settings.local.json`
+- [x] `Agent` is removed from `allowed-tools` in `executing-bug-fixes/SKILL.md`, `executing-chores/SKILL.md`, and `implementing-plan-phases/SKILL.md` (none of the three reference the Agent tool in their instructions)
+- [x] `Glob` is removed from `allowed-tools` in `finalizing-workflow/SKILL.md` (skill does not reference Glob in its instructions)
+- [x] `npm run validate` passes after changes
+- [x] `npm test` passes after changes
+- [ ] Invoking each of the 13 `lwndev-sdlc` skills no longer surfaces a `Skill(...)` permission prompt in a fresh Claude Code session
+
+## Completion
+
+**Status:** `In Progress`
+
+## Notes
+
+### Scope changes since issue was filed (2026-03-28)
+
+#80 was written when the plugin had 12 skills and listed 9 skills as missing Skill rules. The repo has since added `orchestrating-workflows` and `managing-work-items` (13 skills total) and the user has added Skill rules for 11 of them during other work. Only the two newest skills are missing rules today. `orchestrating-workflows/SKILL.md` has no `allowed-tools` declaration at all — that is intentional given its Stop-hook and orchestration role and is out of scope for this chore.
+
+### Bash syntax framing
+
+#80 described the colon syntax as "deprecated" but the official `/anthropics/claude-code` docs still show `Bash(cmd:*)` as the canonical format in *skill/command frontmatter* `allowed-tools`. The settings.json permissions docs (`docs/permissions.md`) document space syntax (`Bash(npm run *)`) as the pattern-matching format and explicitly note that space before `*` enforces a word boundary. The migration in this chore applies only to `.claude/settings.local.json`, not to SKILL.md frontmatter.
+
+### Out of scope
+
+- Broader cleanup of one-off ad-hoc `Bash(...)` entries in `.claude/settings.local.json` that were added during prior debugging sessions
+- Adding an `allowed-tools` list to `orchestrating-workflows/SKILL.md`
+- Rules for skills from other plugins (`Skill(releasing-plugins)`, `Skill(test-auto-fork)`)
+- Re-testing `allowed-tools` format variants (YAML array / space-delimited / comma-separated) — #80's own testing already confirmed all three are accepted by the runtime

--- a/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
+++ b/requirements/chores/CHORE-033-fix-skill-permission-prompts.md
@@ -39,6 +39,8 @@ Add missing `Skill(...)` allow rules for `orchestrating-workflows` and `managing
 
 **Status:** `In Progress`
 
+**Pull Request:** [#161](https://github.com/lwndev/lwndev-marketplace/pull/161)
+
 ## Notes
 
 ### Scope changes since issue was filed (2026-03-28)

--- a/requirements/features/FEAT-016-persist-review-findings.md
+++ b/requirements/features/FEAT-016-persist-review-findings.md
@@ -1,0 +1,244 @@
+# Feature Requirements: Persist Reviewing-Requirements Findings in Workflow State
+
+## Overview
+
+Add findings persistence to the `orchestrating-workflows` skill so that reviewing-requirements results (severity counts, decision taken, and individual finding details) are recorded in the workflow state file after every reviewing-requirements step, regardless of the advance/pause decision. Currently, parsed severity counts and individual finding details are ephemeral — once the workflow advances past a review step, the only record of what was found is lost. This is especially acute on bug/chore chains where FEAT-015 auto-advances on warnings-only findings without surfacing them interactively.
+
+## Feature ID
+`FEAT-016`
+
+## GitHub Issue
+[#145](https://github.com/lwndev/lwndev-marketplace/issues/145)
+
+## Priority
+Medium - Findings from reviewing-requirements steps are lost after auto-advance, preventing post-hoc audit of what was found at each review checkpoint. Info items on auto-advance, warnings the user chose to skip, and post-fix residue all vanish without a trace.
+
+## User Story
+
+As a developer running SDLC workflows, I want the orchestrator to persist reviewing-requirements findings in the workflow state so that I can review what was found at each review step after the workflow has moved past it, without re-running the step.
+
+## Motivation
+
+The workflow state file (`.sdlc/workflows/{ID}.json`) records the decision (`status`, `pauseReason`, `artifact`) but not the findings themselves. Once the workflow advances past a reviewing-requirements step, the only way to see what was found is to re-run the step.
+
+This is particularly relevant for:
+- **Info items on auto-advance**: When all counts are zero or when bug/chore chains auto-advance past warnings/info (per FEAT-015/#139), findings vanish without a trace.
+- **Warnings the user chose to skip**: When the user says "yes" to continue past warnings/info, there's no record of what they accepted.
+- **Post-fix residue**: After the orchestrator applies auto-fixes and re-runs, the re-run findings (if any remain but are non-blocking) are also lost.
+
+## Functional Requirements
+
+### FR-1: Record Findings After Every Reviewing-Requirements Step
+
+After the orchestrator parses the reviewing-requirements subagent's return text (the summary line `Found **N errors**, **N warnings**, **N info**` or "No issues found"), record the findings in the workflow state file **before** making the advance/pause decision. This applies to all three modes (standard, test-plan, code-review) and all chain types (feature, chore, bug).
+
+The recording must happen at every reviewing-requirements step in the chain tables (one-based step numbers; zero-based `stepIndex` values are one less):
+- Feature chain: steps 2, 6, 6+N+3 (zero-based indices 1, 5, 5+N+2)
+- Chore chain: steps 2, 4, 7 (zero-based indices 1, 3, 6)
+- Bug chain: steps 2, 4, 7 (zero-based indices 1, 3, 6)
+
+Skipped steps (CHORE-031 low-complexity skip for steps 2 and 4 on chore/bug chains) do not produce findings and therefore have no `findings` entry.
+
+### FR-2: Findings Schema
+
+Each findings record is stored on the step entry in the `steps` array. Add a `findings` field to reviewing-requirements step entries with the following structure:
+
+```json
+{
+  "findings": {
+    "errors": "<int>",
+    "warnings": "<int>",
+    "info": "<int>",
+    "decision": "<string>",
+    "summary": "<string>",
+    "details": [
+      {
+        "id": "<string>",
+        "severity": "<string>",
+        "category": "<string>",
+        "description": "<string>"
+      }
+    ]
+  }
+}
+```
+
+Fields:
+- `errors` — Count of error-severity findings (integer, >= 0)
+- `warnings` — Count of warning-severity findings (integer, >= 0)
+- `info` — Count of info-severity findings (integer, >= 0)
+- `decision` — The action the orchestrator took after parsing findings. One of:
+  - `"advanced"` — Zero findings; state advanced automatically
+  - `"auto-advanced"` — Warnings/info only; auto-advanced by FR-1 gate (FEAT-015 bug/chore <= medium)
+  - `"user-advanced"` — Warnings/info only; user prompted and confirmed continuation
+  - `"auto-fixed"` — Errors present; user chose "Apply fixes" (records user intent at the decision point; the re-run outcome is captured separately in `rerunFindings.decision`)
+  - `"paused"` — User declined to continue (warnings prompt), or user chose "Pause for manual resolution" on errors
+- `summary` — The raw summary line from the subagent return text, stored verbatim including the trailing `in <filename>` suffix if present (e.g., `"Found **2 errors**, **4 warnings**, **1 info** in FEAT-016-persist-review-findings.md"` or `"No issues found"`). Preserves the exact text for later display; consumers can strip the filename at query time.
+- `details` — Array of individual finding objects. **Required when `decision` is `"auto-advanced"`**; omitted for all other decisions (where the user either sees the findings interactively or there are none to record). Each object contains:
+  - `id` — The finding identifier from the subagent output (e.g., `"W1"`, `"I3"`)
+  - `severity` — One of `"error"`, `"warning"`, `"info"`
+  - `category` — The check category that produced the finding (e.g., `"Codebase References"`, `"Internal Consistency"`, `"Gaps"`, `"Cross-References"`, `"Documentation Citations"`)
+  - `description` — The finding description, trimmed to a single line. Preserves enough context to understand the issue without re-running the review.
+
+### FR-3: Record Re-Run Findings
+
+When the orchestrator applies auto-fixes and re-runs reviewing-requirements (the "Applying Auto-Fixes" path), the re-run also produces findings. Record the re-run findings as a separate entry:
+
+Add a `rerunFindings` field alongside `findings` on the same step entry:
+
+```json
+{
+  "findings": { "..." : "..." },
+  "rerunFindings": {
+    "errors": "<int>",
+    "warnings": "<int>",
+    "info": "<int>",
+    "decision": "<string>",
+    "summary": "<string>"
+  }
+}
+```
+
+The `rerunFindings` field uses the same schema as `findings`. It is only present when an auto-fix + re-run occurred. The `decision` field on the re-run reflects the re-run outcome (`"advanced"`, `"auto-advanced"`, or `"paused"`). The `details` field follows the same conditional rule: required when `decision` is `"auto-advanced"`, omitted otherwise.
+
+### FR-4: `record-findings` Subcommand
+
+Add a `record-findings` subcommand to `workflow-state.sh`:
+
+```
+workflow-state.sh record-findings <ID> <stepIndex> <errors> <warnings> <info> <decision> <summary> [--rerun] [--details-file <path>]
+```
+
+Arguments:
+- `ID` — Workflow ID (e.g., `FEAT-016`)
+- `stepIndex` — Zero-based step index in the `steps` array
+- `errors` — Error count (integer)
+- `warnings` — Warning count (integer)
+- `info` — Info count (integer)
+- `decision` — One of: `advanced`, `auto-advanced`, `user-advanced`, `auto-fixed`, `paused`
+- `summary` — The raw summary line (quoted string; must be passed as a single shell-quoted token)
+- `--rerun` — Optional flag. When present, writes to `rerunFindings` instead of `findings`.
+- `--details-file <path>` — Optional. Path to a JSON file containing the `details` array. **Required when `decision` is `auto-advanced`**; ignored for other decisions. The file must contain a JSON array of finding objects matching the `details` schema (see FR-2). The subcommand reads the file, validates it is a JSON array, and merges it into the findings object. The caller is responsible for writing the temp file and cleaning it up after the call.
+
+The subcommand writes the findings object to `steps[stepIndex].findings` (or `steps[stepIndex].rerunFindings` with `--rerun`) using `jq` and persists the state file. When `--details-file` is provided and `decision` is `auto-advanced`, the `details` array from the file is included in the written object. When `--details-file` is omitted or `decision` is not `auto-advanced`, the `details` field is not written.
+
+### FR-5: Orchestrator Integration Points
+
+Update the Reviewing-Requirements Findings Handling section in the orchestrating-workflows SKILL.md to call `record-findings` at each decision point:
+
+1. **Zero findings (auto-advance)**: Call `record-findings {ID} {stepIndex} 0 0 0 advanced "No issues found"` before calling `advance`. Note: if the subagent returns `Found **0 errors**, **0 warnings**, **0 info**` (parseable as zeros), normalize the summary to `"No issues found"` — both forms mean zero findings, but `"No issues found"` is the canonical summary.
+2. **Warnings/info only, auto-advanced (FEAT-015 gate)**: Parse the individual findings from the subagent's return text (each `[W1]`, `[I1]`, etc. entry), build a JSON array of finding objects matching the `details` schema, write it to a temp file, and call `record-findings {ID} {stepIndex} 0 {W} {I} auto-advanced "{summary}" --details-file {tmp-path}` before calling `advance`. Clean up the temp file after the call. See FR-7 for the parsing specification.
+3. **Warnings/info only, user prompted and confirmed**: Call `record-findings {ID} {stepIndex} 0 {W} {I} user-advanced "{summary}"` before calling `advance`.
+4. **Warnings/info only, user declined**: Call `record-findings {ID} {stepIndex} 0 {W} {I} paused "{summary}"` before calling `pause`.
+5. **Errors present, user chose "Apply fixes"**: Call `record-findings {ID} {stepIndex} {E} {W} {I} auto-fixed "{summary}"` at the decision point (before applying fixes — `auto-fixed` records user intent, not re-run outcome). After the re-run, call `record-findings {ID} {stepIndex} {E2} {W2} {I2} {rerun-decision} "{rerun-summary}" --rerun`. The `rerunFindings.decision` captures the re-run outcome: `"advanced"` if zero errors after fix, `"auto-advanced"` if warnings/info only on a bug/chore chain with `complexity <= medium` (requires `--details-file` per FR-2), `"paused"` if errors remain.
+6. **Errors present, user chose "Pause"**: Call `record-findings {ID} {stepIndex} {E} {W} {I} paused "{summary}"` before calling `pause`.
+
+### FR-6: Queryable via `status` Subcommand
+
+The existing `status` subcommand (which returns the full state JSON) already exposes the `steps` array. No additional query subcommand is needed — consumers can use `jq` to extract findings:
+
+```bash
+# Get findings for step 2 (standard review) — zero-based index 1
+jq '.steps[1].findings' ".sdlc/workflows/FEAT-016.json"
+
+# List all reviewing-requirements findings across the workflow
+jq '[.steps[] | select(.skill == "reviewing-requirements") | {name, findings, rerunFindings}]' ".sdlc/workflows/FEAT-016.json"
+
+# List auto-advanced finding details (warnings/info that bypassed user review)
+jq '[.steps[] | select(.findings.decision == "auto-advanced") | .findings.details[]]' ".sdlc/workflows/FEAT-016.json"
+```
+
+### FR-7: Parsing Finding Details from Subagent Output
+
+When the decision is `auto-advanced`, the orchestrator must extract individual findings from the subagent's return text before calling `record-findings`. The reviewing-requirements skill outputs findings in this format:
+
+```
+**[W1] Category — Description**
+Additional context lines...
+
+**[I1] Category — Description**
+Additional context lines...
+```
+
+The orchestrator parses these into the `details` array by:
+
+1. **Scanning** the subagent return text for lines matching the pattern `**[{severity}{number}] {category} — {description}**` (or the variant without bold markers: `[{severity}{number}] {category} — {description}`). The separator between category and description is an em dash (`—`, U+2014); the parser should also accept an ASCII double-hyphen (`--`) as a fallback. The severity prefix maps as: `E` → `"error"`, `W` → `"warning"`, `I` → `"info"`.
+2. **Extracting** for each match:
+   - `id` — The severity+number token (e.g., `"W1"`, `"I3"`)
+   - `severity` — Mapped from the prefix letter
+   - `category` — The text between `]` and `—` (trimmed)
+   - `description` — The text after `—` to end of line (trimmed, stripped of trailing bold markers)
+3. **Writing** the resulting JSON array to a temp file at `/tmp/findings-{ID}-{stepIndex}.json`
+4. **Passing** the path via `--details-file` to `record-findings`
+5. **Cleaning up** the temp file after `record-findings` returns
+
+If no individual findings can be parsed from the subagent text (despite non-zero warning/info counts), write an empty array `[]` and log: `[warn] Could not parse individual findings from reviewing-requirements output — recording counts only.`
+
+## Non-Functional Requirements
+
+### NFR-1: Backwards Compatibility
+
+The `findings` and `rerunFindings` fields are additive. Existing state files without these fields remain valid. The `status` subcommand does not require these fields to be present. No migration is needed for existing workflows.
+
+### NFR-2: No Impact on Decision Flow
+
+The findings recording happens independently of the advance/pause decision. The existing Decision Flow logic (zero findings → advance, warnings-only → gate, errors → prompt) is unchanged. `record-findings` is called at each decision point but does not influence the decision itself.
+
+### NFR-3: Recording Before Decision Execution
+
+`record-findings` must be called **before** `advance` or `pause` at every decision point. This ensures that if the `advance`/`pause` call fails or the process crashes, the findings are still persisted.
+
+### NFR-4: Scope of Changes
+
+Changes are limited to:
+1. `workflow-state.sh` — Add the `record-findings` subcommand and its usage entry
+2. `orchestrating-workflows/SKILL.md` — Add `record-findings` calls at each decision point in the Reviewing-Requirements Findings Handling section
+3. No changes to the `reviewing-requirements` skill itself
+4. No changes to any other subcommand's behavior
+
+## Edge Cases
+
+1. **Subagent returns no parseable summary line**: If the subagent returns text that does not contain the `Found **N errors**...` pattern or "No issues found", record `errors=0, warnings=0, info=0, decision="advanced", summary="(unparseable)"`. Log a warning: `[warn] Could not parse reviewing-requirements summary — recording as zero findings.`
+2. **Step skipped by CHORE-031**: Skipped steps call `advance` without spawning a reviewing-requirements fork. No `findings` field is written. The `findings` field being absent signals "step was skipped". The CHORE-031 skip path requires no modification — no `record-findings` call is inserted on the skip path.
+3. **Re-run not triggered**: When the initial findings have zero errors, or the user chooses "Pause" on errors, no re-run occurs. The `rerunFindings` field is absent, signaling "no re-run happened".
+4. **Summary line contains shell-special characters**: The `summary` argument to `record-findings` must be quoted. The subcommand handles embedded quotes and special characters safely via `jq --arg`.
+5. **Concurrent state file writes**: The `record-findings` and `advance`/`pause` calls are sequential (FR-5 calls `record-findings` before `advance`/`pause`), so no concurrent write conflict occurs within a single workflow.
+6. **Details parsing produces fewer items than severity counts**: If the parser extracts 2 findings but the summary line reports 3 warnings, record what was parsed. The counts in `errors`/`warnings`/`info` come from the summary line (authoritative); the `details` array is best-effort. A mismatch is not an error.
+7. **Details file does not exist or is not valid JSON**: If `--details-file` points to a missing file or the file does not contain a valid JSON array, `record-findings` writes the findings object without a `details` field and logs: `[warn] Could not read details file — recording counts only.`
+
+## Dependencies
+
+- `jq` — Already a dependency of `workflow-state.sh`
+- FEAT-015 / #139 — The auto-advance gate for bug/chore chains (FR-1 gate, `auto-advanced` decision value) depends on the FEAT-015 behavior being in place
+
+## Testing Requirements
+
+### Unit Tests
+- `record-findings` subcommand: verify it writes the correct JSON structure to the state file
+- `record-findings --rerun`: verify it writes to `rerunFindings` without overwriting `findings`
+- `record-findings` with shell-special characters in summary: verify safe handling
+- `record-findings --details-file`: verify the `details` array is included when `decision` is `auto-advanced`
+- `record-findings --details-file` with non-`auto-advanced` decision: verify `details` is not written
+- `record-findings --details-file` with invalid JSON file: verify graceful error handling
+- `record-findings` with out-of-bounds `stepIndex`: verify graceful error handling
+- `status` subcommand: verify it returns findings data (including `details`) when present and works when absent
+
+### Manual Testing
+- Run a bug or chore workflow where reviewing-requirements returns zero findings. Verify `findings` field with `decision: "advanced"` appears on the step entry.
+- Run a bug or chore workflow (complexity <= medium) where reviewing-requirements returns warnings-only. Verify `findings` field with `decision: "auto-advanced"` and a populated `details` array.
+- Run a feature workflow where reviewing-requirements returns warnings-only and the user confirms. Verify `findings` field with `decision: "user-advanced"`.
+- Run a workflow where reviewing-requirements returns errors, user applies fixes, and re-run succeeds. Verify both `findings` (with `decision: "auto-fixed"`) and `rerunFindings` (with `decision: "advanced"`).
+- Run a workflow where reviewing-requirements returns errors, user applies fixes, and re-run still has errors. Verify `findings` (with `decision: "auto-fixed"`) and `rerunFindings` (with `decision: "paused"`).
+- Run a workflow where reviewing-requirements returns errors and user pauses. Verify `findings` field with `decision: "paused"`.
+- Inspect a completed workflow state file and confirm all reviewing-requirements steps have findings recorded.
+
+## Acceptance Criteria
+
+- [ ] After every non-skipped reviewing-requirements step, the workflow state file contains a `findings` object on the step entry with `errors`, `warnings`, `info`, `decision`, and `summary` fields
+- [ ] Auto-advanced steps (FEAT-015 warnings-only gate) include a `findings` record with a `details` array containing each individual finding's `id`, `severity`, `category`, and `description`
+- [ ] Non-auto-advanced steps (zero findings, user-advanced, auto-fixed, paused) include a `findings` record without a `details` array
+- [ ] When auto-fixes are applied and a re-run occurs, both `findings` and `rerunFindings` are present on the step entry
+- [ ] Skipped steps (CHORE-031 low-complexity) have no `findings` field, distinguishing "skipped" from "zero findings"
+- [ ] The `record-findings` subcommand in `workflow-state.sh` correctly persists findings with all decision variants
+- [ ] Existing workflow state files without `findings` fields remain valid (no migration needed)
+- [ ] The Decision Flow logic is unchanged — `record-findings` is additive and does not influence advance/pause decisions

--- a/scripts/__tests__/executing-bug-fixes.test.ts
+++ b/scripts/__tests__/executing-bug-fixes.test.ts
@@ -83,7 +83,7 @@ describe('executing-bug-fixes skill', () => {
       expect(skillMd).toMatch(/^---\s*\n[\s\S]*?allowed-tools:[\s\S]*?---/);
     });
 
-    it('should include Read, Write, Edit, Bash, Glob, Grep, Agent', () => {
+    it('should include Read, Write, Edit, Bash, Glob, Grep', () => {
       const frontmatter = skillMd.match(/^---\s*\n([\s\S]*?)---/)?.[1] ?? '';
       expect(frontmatter).toContain('- Read');
       expect(frontmatter).toContain('- Write');
@@ -91,7 +91,7 @@ describe('executing-bug-fixes skill', () => {
       expect(frontmatter).toContain('- Bash');
       expect(frontmatter).toContain('- Glob');
       expect(frontmatter).toContain('- Grep');
-      expect(frontmatter).toContain('- Agent');
+      expect(frontmatter).not.toContain('- Agent');
     });
   });
 

--- a/scripts/__tests__/executing-chores.test.ts
+++ b/scripts/__tests__/executing-chores.test.ts
@@ -76,7 +76,7 @@ describe('executing-chores skill', () => {
       expect(skillMd).toMatch(/^---\s*\n[\s\S]*?allowed-tools:[\s\S]*?---/);
     });
 
-    it('should include Read, Write, Edit, Bash, Glob, Grep, Agent', () => {
+    it('should include Read, Write, Edit, Bash, Glob, Grep', () => {
       const frontmatter = skillMd.match(/^---\s*\n([\s\S]*?)---/)?.[1] ?? '';
       expect(frontmatter).toContain('- Read');
       expect(frontmatter).toContain('- Write');
@@ -84,7 +84,7 @@ describe('executing-chores skill', () => {
       expect(frontmatter).toContain('- Bash');
       expect(frontmatter).toContain('- Glob');
       expect(frontmatter).toContain('- Grep');
-      expect(frontmatter).toContain('- Agent');
+      expect(frontmatter).not.toContain('- Agent');
     });
   });
 

--- a/scripts/__tests__/implementing-plan-phases.test.ts
+++ b/scripts/__tests__/implementing-plan-phases.test.ts
@@ -82,7 +82,7 @@ describe('implementing-plan-phases skill', () => {
       expect(skillMd).toMatch(/^---\s*\n[\s\S]*?allowed-tools:[\s\S]*?---/);
     });
 
-    it('should include Read, Write, Edit, Bash, Glob, Grep, Agent', () => {
+    it('should include Read, Write, Edit, Bash, Glob, Grep', () => {
       const frontmatter = skillMd.match(/^---\s*\n([\s\S]*?)---/)?.[1] ?? '';
       expect(frontmatter).toContain('- Read');
       expect(frontmatter).toContain('- Write');
@@ -90,7 +90,7 @@ describe('implementing-plan-phases skill', () => {
       expect(frontmatter).toContain('- Bash');
       expect(frontmatter).toContain('- Glob');
       expect(frontmatter).toContain('- Grep');
-      expect(frontmatter).toContain('- Agent');
+      expect(frontmatter).not.toContain('- Agent');
     });
   });
 


### PR DESCRIPTION
## Chore
[CHORE-033](requirements/chores/CHORE-033-fix-skill-permission-prompts.md)

## Summary
- Remove unused `Agent` from `allowed-tools` in `executing-bug-fixes`, `executing-chores`, and `implementing-plan-phases` SKILL.md files
- Remove unused `Glob` from `allowed-tools` in `finalizing-workflow` SKILL.md
- Update corresponding tests to assert `Agent` is absent from the three skill frontmatters
- Apply local `.claude/settings.local.json` changes (gitignored): add two missing `Skill(lwndev-sdlc:orchestrating-workflows)` and `Skill(lwndev-sdlc:managing-work-items)` allow rules, remove stale unprefixed `Skill(implementing-plan-phases)`, migrate simple `Bash(cmd:*)` entries to `Bash(cmd *)` space syntax

## Changes
- `plugins/lwndev-sdlc/skills/executing-bug-fixes/SKILL.md` — remove `Agent` from `allowed-tools`
- `plugins/lwndev-sdlc/skills/executing-chores/SKILL.md` — remove `Agent` from `allowed-tools`
- `plugins/lwndev-sdlc/skills/implementing-plan-phases/SKILL.md` — remove `Agent` from `allowed-tools`
- `plugins/lwndev-sdlc/skills/finalizing-workflow/SKILL.md` — remove `Glob` from `allowed-tools`
- `scripts/__tests__/executing-bug-fixes.test.ts` — update allowed-tools assertion
- `scripts/__tests__/executing-chores.test.ts` — update allowed-tools assertion
- `scripts/__tests__/implementing-plan-phases.test.ts` — update allowed-tools assertion
- `requirements/chores/CHORE-033-fix-skill-permission-prompts.md` — mark AC1–AC7 complete, status In Progress

## Carried commit
This PR also carries `2d0df06 docs(FEAT-016): add retroactive feature requirements document`, which was authored against already-merged FEAT-016 work (PR #158) on local main but never pushed separately. It rides along here to reach origin/main.

## Testing
- [x] Tests pass (752/752)
- [x] Build succeeds (\`npm run validate\` — 13/13 skills pass)
- [x] Linting passes

## Related
- Closes #80

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)