### PR TITLE
FEAT-017: remove advisory code-review reconciliation step from orchestrator

### DIFF
--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md
@@ -59,7 +59,7 @@ For the full issue tracking protocol — extraction, invocation pattern, runnabl
 
 ## Feature Chain Step Sequence
 
-The feature chain has 6 + N + 5 steps where N = number of implementation phases:
+The feature chain has 6 + N + 4 steps where N = number of implementation phases:
 
 | # | Step | Skill | Context |
 |---|------|-------|---------|
@@ -72,13 +72,12 @@ The feature chain has 6 + N + 5 steps where N = number of implementation phases:
 | 7…6+N | Implement phases 1…N | `implementing-plan-phases` | fork |
 | 6+N+1 | Create PR | orchestrator | fork |
 | 6+N+2 | **PAUSE: PR review** | — | pause |
-| 6+N+3 | Reconcile post-review | `reviewing-requirements` | fork |
-| 6+N+4 | Execute QA | `executing-qa` | **main** |
-| 6+N+5 | Finalize | `finalizing-workflow` | fork |
+| 6+N+3 | Execute QA | `executing-qa` | **main** |
+| 6+N+4 | Finalize | `finalizing-workflow` | fork |
 
 ## Chore Chain Step Sequence
 
-The chore chain has a fixed 9 steps with no phase loop and no plan-approval pause:
+The chore chain has a fixed 8 steps with no phase loop and no plan-approval pause:
 
 | # | Step | Skill | Context |
 |---|------|-------|---------|
@@ -88,13 +87,12 @@ The chore chain has a fixed 9 steps with no phase loop and no plan-approval paus
 | 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 5 | Execute chore | `executing-chores` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
-| 7 | Reconcile post-review | `reviewing-requirements` | fork |
-| 8 | Execute QA | `executing-qa` | **main** |
-| 9 | Finalize | `finalizing-workflow` | fork |
+| 7 | Execute QA | `executing-qa` | **main** |
+| 8 | Finalize | `finalizing-workflow` | fork |
 
 ## Bug Chain Step Sequence
 
-The bug chain has a fixed 9 steps with no phase loop and no plan-approval pause, mirroring the chore chain structure with bug-specific skills:
+The bug chain has a fixed 8 steps with no phase loop and no plan-approval pause, mirroring the chore chain structure with bug-specific skills:
 
 | # | Step | Skill | Context |
 |---|------|-------|---------|
@@ -104,9 +102,8 @@ The bug chain has a fixed 9 steps with no phase loop and no plan-approval pause,
 | 4 | Reconcile test plan | `reviewing-requirements` | fork (skip if `complexity == low`) |
 | 5 | Execute bug fix | `executing-bug-fixes` | fork |
 | 6 | **PAUSE: PR review** | — | pause |
-| 7 | Reconcile post-review | `reviewing-requirements` | fork |
-| 8 | Execute QA | `executing-qa` | **main** |
-| 9 | Finalize | `finalizing-workflow` | fork |
+| 7 | Execute QA | `executing-qa` | **main** |
+| 8 | Finalize | `finalizing-workflow` | fork |
 
 ## Chain Workflow Procedures
 
@@ -122,7 +119,7 @@ For each step, determine the context from the appropriate step sequence table (F
 
 These steps run directly in the orchestrator's conversation because they rely on Stop hooks or interactive prompts that don't work when forked.
 
-#### Feature Chain Main-Context Steps (Steps 1, 5, 6+N+4)
+#### Feature Chain Main-Context Steps (Steps 1, 5, 6+N+3)
 
 **Step 1 — `documenting-features`**: See New Feature Workflow Procedure above.
 
@@ -132,13 +129,13 @@ These steps run directly in the orchestrator's conversation because they rely on
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-plans/QA-plan-{ID}.md"
 ```
 
-**Step 6+N+4 — `executing-qa`**: Read the SKILL.md content from `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`. Follow its instructions directly in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
+**Step 6+N+3 — `executing-qa`**: Read the SKILL.md content from `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`. Follow its instructions directly in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-results-{ID}.md"
 ```
 
-#### Chore Chain Main-Context Steps (Steps 1, 3, 8)
+#### Chore Chain Main-Context Steps (Steps 1, 3, 7)
 
 **Step 1 — `documenting-chores`**: See New Chore Workflow Procedure above.
 
@@ -148,7 +145,7 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-r
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-plans/QA-plan-{ID}.md"
 ```
 
-**Step 8 — `executing-qa`**: Same pattern as feature chain step 6+N+4. Read `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`, follow its instructions in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
+**Step 7 — `executing-qa`**: Same pattern as feature chain step 6+N+3. Read `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`, follow its instructions in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-results-{ID}.md"
@@ -235,7 +232,7 @@ The `resolve-tier` and `record-model-selection` subcommands key off canonical st
 
 | Fork site | Step-name | Baseline | Baseline-locked? |
 |-----------|-----------|----------|------------------|
-| Review requirements (standard / test-plan / code-review) | `reviewing-requirements` | sonnet | no |
+| Review requirements (standard / test-plan) | `reviewing-requirements` | sonnet | no |
 | Create implementation plan | `creating-implementation-plans` | sonnet | no |
 | Implement phases (per-phase) | `implementing-plan-phases` | sonnet | no |
 | Execute chore | `executing-chores` | sonnet | no |
@@ -243,11 +240,11 @@ The `resolve-tier` and `record-model-selection` subcommands key off canonical st
 | Finalize workflow | `finalizing-workflow` | haiku | **yes** |
 | PR creation (inline fork) | `pr-creation` | haiku | **yes** |
 
-For `reviewing-requirements` call sites, pass the mode (`standard`, `test-plan`, `code-review`) as the `mode` argument of `record-model-selection`. For `implementing-plan-phases`, pass the phase number as the `phase` argument. All other sites pass `null` for both.
+For `reviewing-requirements` call sites, pass the mode (`standard`, `test-plan`) as the `mode` argument of `record-model-selection`. For `implementing-plan-phases`, pass the phase number as the `phase` argument. All other sites pass `null` for both.
 
 ### Reviewing-Requirements Findings Handling
 
-All `reviewing-requirements` fork steps (feature steps 2, 6, 6+N+3; chore steps 2, 4, 7; bug steps 2, 4, 7) require findings handling after the subagent returns. The orchestrator parses the subagent's return text and acts on the findings before advancing.
+All `reviewing-requirements` fork steps (feature steps 2, 6; chore steps 2, 4; bug steps 2, 4) require findings handling after the subagent returns. The orchestrator parses the subagent's return text and acts on the findings before advancing.
 
 #### Parsing Findings
 
@@ -259,7 +256,7 @@ Found **N errors**, **N warnings**, **N info**
 
 Extract the error, warning, and info counts from this line. If the summary line is not found (e.g., the subagent returned "No issues found"), treat as zero errors, zero warnings, zero info.
 
-> **Note**: Anchor the count-extraction regex on the `Found **N errors**` substring rather than the start of the line. Subagent output in test-plan and code-review modes may include a mode prefix (e.g., `"Test-plan reconciliation for {ID}: Found **N errors**..."`) before the counts — anchoring on the substring handles these prefixes correctly.
+> **Note**: Anchor the count-extraction regex on the `Found **N errors**` substring rather than the start of the line. Subagent output in test-plan mode may include a mode prefix (e.g., `"Test-plan reconciliation for {ID}: Found **N errors**..."`) before the counts — anchoring on the substring handles these prefixes correctly.
 
 #### Decision Flow
 
@@ -371,7 +368,7 @@ At every reviewing-requirements decision point, call `record-findings` **before*
 | Re-run after auto-fix → auto-advanced | (same as above plus `--details-file {tmp}`) |
 
 Notes:
-- `{stepIndex}` is the zero-based index in the `steps` array for the current reviewing-requirements step. Use the chain-step-to-index table: feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6.
+- `{stepIndex}` is the zero-based index in the `steps` array for the current reviewing-requirements step. Use the chain-step-to-index table: feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3.
 - When the subagent returns `"No issues found"` or `Found **0 errors**, **0 warnings**, **0 info**`, normalize to `'No issues found'` as the canonical summary.
 - The `{summary}` must be passed as a single shell-quoted token. Use single quotes around the summary string to handle embedded special characters.
 

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md
@@ -370,9 +370,12 @@ overwriting earlier ones.
   Matches the step order shown by `workflow-state.sh status`.
 - **`skill`** — the forked skill's name. For inline forks not backed by a
   standalone skill (PR creation), this is `"pr-creation"`.
-- **`mode`** — populated for `reviewing-requirements` only. One of
-  `"standard"`, `"test-plan"`, or `"code-review"`. `null` for every other
-  skill.
+- **`mode`** — populated for `reviewing-requirements` only. The
+  orchestrator writes one of `"standard"` or `"test-plan"`; `"code-review"`
+  is a valid historical value that remains readable for backwards
+  compatibility (pre-FEAT-017 state files and manual invocations of
+  `/reviewing-requirements --pr` may still record it, but the orchestrator
+  no longer writes it). `null` for every other skill.
 - **`phase`** — populated for `implementing-plan-phases` only. One-based
   phase number (e.g. `1` for the first phase). `null` for every other
   skill.

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md
@@ -20,13 +20,11 @@ If the plan file is missing or malformed, `classify-post-plan` retains the init-
 
 **Step 6+N+1 — Create PR**: See PR Creation below.
 
-**Step 6+N+3 — `reviewing-requirements` (code-review reconciliation)**: Append `{ID} --pr {prNumber}` as argument. The skill auto-detects code-review reconciliation mode. Run the FEAT-014 pre-fork sequence with step-name `reviewing-requirements` and mode `code-review`.
-
-**Step 6+N+5 — `finalizing-workflow`**: No special argument needed. The skill merges the current PR and resets to main. Run the FEAT-014 pre-fork sequence with step-name `finalizing-workflow`. This step is **baseline-locked** at `haiku` — the pre-fork echo uses the `baseline-locked` tag, and only a hard override (`--model`, `--model-for`) can push it off its baseline.
+**Step 6+N+4 — `finalizing-workflow`**: No special argument needed. The skill merges the current PR and resets to main. Run the FEAT-014 pre-fork sequence with step-name `finalizing-workflow`. This step is **baseline-locked** at `haiku` — the pre-fork echo uses the `baseline-locked` tag, and only a hard override (`--model`, `--model-for`) can push it off its baseline.
 
 ### Chore Chain Step-Specific Fork Instructions
 
-Steps 2, 4, 7, and 9 follow the same fork pattern as the feature chain without chore-specific overrides. Every non-skipped fork runs the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-14 echo) with the appropriate step-name and mode before spawning the subagent, and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
+Steps 2, 4, and 8 follow the same fork pattern as the feature chain without chore-specific overrides. Every non-skipped fork runs the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-14 echo) with the appropriate step-name and mode before spawning the subagent, and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
 
 **Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
@@ -55,11 +53,9 @@ Run the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-1
 
 After step 5 completes (if `issueRef` is set): invoke `managing-work-items comment <issueRef> --type work-complete --context '{"workItemId": "{ID}", "prNumber": <pr-number>}'` inline per "How to Invoke `managing-work-items`" in [issue-tracking.md](issue-tracking.md).
 
-**Step 7 — `reviewing-requirements` (code-review reconciliation)**: Append `{ID} --pr {prNumber}` as argument. Pre-fork step-name `reviewing-requirements`, mode `code-review`.
+**Step 8 — `finalizing-workflow`**: No special argument needed. Pre-fork step-name `finalizing-workflow` (baseline-locked `haiku`; echo uses the `baseline-locked` tag).
 
-**Step 9 — `finalizing-workflow`**: No special argument needed. Pre-fork step-name `finalizing-workflow` (baseline-locked `haiku`; echo uses the `baseline-locked` tag).
-
-### Bug Chain Main-Context Steps (Steps 1, 3, 8)
+### Bug Chain Main-Context Steps (Steps 1, 3, 7)
 
 **Step 1 — `documenting-bugs`**: See New Bug Workflow Procedure in [chain-procedures.md](chain-procedures.md).
 
@@ -69,7 +65,7 @@ After step 5 completes (if `issueRef` is set): invoke `managing-work-items comme
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-plans/QA-plan-{ID}.md"
 ```
 
-**Step 8 — `executing-qa`**: Same pattern as chore chain step 8. Read `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`, follow its instructions in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
+**Step 7 — `executing-qa`**: Same pattern as chore chain step 7. Read `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/SKILL.md`, follow its instructions in this conversation, passing the workflow ID as argument. Expected artifact: `qa/test-results/QA-results-{ID}.md`. On completion:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-results-{ID}.md"
@@ -77,7 +73,7 @@ ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh advance {ID} "qa/test-results/QA-r
 
 ### Bug Chain Step-Specific Fork Instructions
 
-Steps 2, 4, 7, and 9 follow the same fork pattern as the chore chain. Every non-skipped fork runs the FEAT-014 pre-fork sequence before spawning the subagent and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
+Steps 2, 4, and 8 follow the same fork pattern as the chore chain. Every non-skipped fork runs the FEAT-014 pre-fork sequence before spawning the subagent and passes the resolved tier as the Agent tool's `model` parameter. Steps skipped by CHORE-031 conditions call only `advance` — no pre-fork sequence, no audit trail entry, and no `modelSelections` entry for that step index:
 
 **Step 2 — `reviewing-requirements` (standard review)**: **Skip condition (CHORE-031 T2)**: read the persisted complexity from the state file (`jq -r '.complexity' ".sdlc/workflows/{ID}.json"`). If `complexity == low`, skip this fork — advance state without spawning a subagent:
 ```bash
@@ -106,9 +102,7 @@ Run the FEAT-014 pre-fork sequence (resolve-tier / record-model-selection / FR-1
 
 After step 5 completes (if `issueRef` is set): invoke `managing-work-items comment <issueRef> --type bug-complete --context '{"workItemId": "{ID}", "prNumber": <pr-number>}'` inline per "How to Invoke `managing-work-items`" in [issue-tracking.md](issue-tracking.md).
 
-**Step 7 — `reviewing-requirements` (code-review reconciliation)**: Append `{ID} --pr {prNumber}` as argument. Pre-fork step-name `reviewing-requirements`, mode `code-review`.
-
-**Step 9 — `finalizing-workflow`**: No special argument needed. Pre-fork step-name `finalizing-workflow` (baseline-locked `haiku`; echo uses the `baseline-locked` tag).
+**Step 8 — `finalizing-workflow`**: No special argument needed. Pre-fork step-name `finalizing-workflow` (baseline-locked `haiku`; echo uses the `baseline-locked` tag).
 
 ### Pause Steps
 
@@ -157,7 +151,7 @@ After step 6 (test-plan reconciliation) completes:
    ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh phase-count {ID}
    ${CLAUDE_SKILL_DIR}/scripts/workflow-state.sh populate-phases {ID} {count}
    ```
-   This inserts N phase steps and 5 post-phase steps (Create PR, PR review, Reconcile post-review, Execute QA, Finalize) into the state file after the initial 6 steps.
+   This inserts N phase steps and 4 post-phase steps (Create PR, PR review, Execute QA, Finalize) into the state file after the initial 6 steps.
 
 2. For each phase 1 through N:
 

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md
@@ -7,7 +7,7 @@ Before marking the workflow complete:
 - [ ] State file at `.sdlc/workflows/{ID}.json` reflects completion
 - [ ] Artifacts exist for all completed steps
 - [ ] Sub-skills were NOT modified — no `context: fork` added to their frontmatter
-- [ ] Reconciliation steps (reviewing-requirements in test-plan and code-review modes) were not skipped — unless CHORE-031 skip conditions apply (bug/chore chains: step 2 skipped if `complexity == low`; step 4 skipped if `complexity == low`)
+- [ ] Reconciliation steps (reviewing-requirements in test-plan mode) were not skipped — unless CHORE-031 skip conditions apply (bug/chore chains: step 2 skipped if `complexity == low`; step 4 skipped if `complexity == low`)
 - [ ] Stop hook prevents premature stopping during in-progress steps
 
 ### Feature Chain Checks
@@ -17,13 +17,13 @@ Before marking the workflow complete:
 
 ### Chore Chain Checks
 - [ ] No plan-approval pause occurred (chore chains skip this)
-- [ ] No phase loop was executed (chore chains have a fixed 9-step sequence)
+- [ ] No phase loop was executed (chore chains have a fixed 8-step sequence)
 - [ ] PR number was extracted from `executing-chores` output or detected via `gh pr list` fallback
 - [ ] `set-pr` was called with the correct PR number and branch after step 5
 
 ### Bug Chain Checks
 - [ ] No plan-approval pause occurred (bug chains skip this)
-- [ ] No phase loop was executed (bug chains have a fixed 9-step sequence)
+- [ ] No phase loop was executed (bug chains have a fixed 8-step sequence)
 - [ ] PR number was extracted from `executing-bug-fixes` output or detected via `gh pr list` fallback
 - [ ] `set-pr` was called with the correct PR number and branch after step 5
 - [ ] RC-N traceability maintained through the chain (delegated to sub-skills)
@@ -60,21 +60,21 @@ documenting-features → [managing-work-items: extract issueRef]
   → PAUSE → documenting-qa → reviewing-requirements (test-plan)
   → [managing-work-items: phase-start] → implementing-plan-phases (×N) → [managing-work-items: phase-completion]
   → Create PR [managing-work-items: FR-6 issue link]
-  → PAUSE → reviewing-requirements (code-review) → executing-qa → finalizing-workflow
+  → PAUSE → executing-qa → finalizing-workflow
 
 Chore chain:
 documenting-chores → [managing-work-items: extract issueRef]
   → reviewing-requirements (standard) → documenting-qa
   → reviewing-requirements (test-plan)
   → [managing-work-items: work-start] → executing-chores [managing-work-items: FR-6 issue link] → [managing-work-items: work-complete]
-  → PAUSE → reviewing-requirements (code-review) → executing-qa → finalizing-workflow
+  → PAUSE → executing-qa → finalizing-workflow
 
 Bug chain:
 documenting-bugs → [managing-work-items: extract issueRef]
   → reviewing-requirements (standard) → documenting-qa
   → reviewing-requirements (test-plan)
   → [managing-work-items: bug-start] → executing-bug-fixes [managing-work-items: FR-6 issue link] → [managing-work-items: bug-complete]
-  → PAUSE → reviewing-requirements (code-review) → executing-qa → finalizing-workflow
+  → PAUSE → executing-qa → finalizing-workflow
 ```
 
 ### Feature Chain Skills
@@ -83,12 +83,12 @@ documenting-bugs → [managing-work-items: extract issueRef]
 |------|-------|
 | Document feature requirements | `documenting-features` (step 1, main) |
 | Issue tracking (fetch, comments, PR link) | `managing-work-items` (after step 1, before/after phases, at PR creation) |
-| Review requirements | `reviewing-requirements` (steps 2/6/6+N+3, fork) |
+| Review requirements | `reviewing-requirements` (steps 2/6, fork) |
 | Create implementation plan | `creating-implementation-plans` (step 3, fork) |
 | Document QA test plan | `documenting-qa` (step 5, main) |
 | Implement phases | `implementing-plan-phases` (steps 7…6+N, fork) |
-| Execute QA verification | `executing-qa` (step 6+N+4, main) |
-| Merge and finalize | `finalizing-workflow` (step 6+N+5, fork) |
+| Execute QA verification | `executing-qa` (step 6+N+3, main) |
+| Merge and finalize | `finalizing-workflow` (step 6+N+4, fork) |
 
 ### Chore Chain Skills
 
@@ -96,11 +96,11 @@ documenting-bugs → [managing-work-items: extract issueRef]
 |------|-------|
 | Document chore requirements | `documenting-chores` (step 1, main) |
 | Issue tracking (comments, PR link) | `managing-work-items` (after step 1, before/after step 5) |
-| Review requirements | `reviewing-requirements` (steps 2/4/7, fork) |
+| Review requirements | `reviewing-requirements` (steps 2/4, fork) |
 | Document QA test plan | `documenting-qa` (step 3, main) |
 | Execute chore implementation | `executing-chores` (step 5, fork) |
-| Execute QA verification | `executing-qa` (step 8, main) |
-| Merge and finalize | `finalizing-workflow` (step 9, fork) |
+| Execute QA verification | `executing-qa` (step 7, main) |
+| Merge and finalize | `finalizing-workflow` (step 8, fork) |
 
 ### Bug Chain Skills
 
@@ -108,8 +108,8 @@ documenting-bugs → [managing-work-items: extract issueRef]
 |------|-------|
 | Document bug report | `documenting-bugs` (step 1, main) |
 | Issue tracking (comments, PR link) | `managing-work-items` (after step 1, before/after step 5) |
-| Review requirements | `reviewing-requirements` (steps 2/4/7, fork) |
+| Review requirements | `reviewing-requirements` (steps 2/4, fork) |
 | Document QA test plan | `documenting-qa` (step 3, main) |
 | Execute bug fix | `executing-bug-fixes` (step 5, fork) |
-| Execute QA verification | `executing-qa` (step 8, main) |
-| Merge and finalize | `finalizing-workflow` (step 9, fork) |
+| Execute QA verification | `executing-qa` (step 7, main) |
+| Merge and finalize | `finalizing-workflow` (step 8, fork) |

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -809,7 +809,7 @@ STEPS
 }
 
 # Generate the chore chain step sequence (FR-1)
-# Fixed 9-step sequence with a single PR-review pause point, no phase loop
+# Fixed 8-step sequence with a single PR-review pause point, no phase loop
 generate_chore_steps() {
   cat <<'STEPS'
 [
@@ -819,7 +819,6 @@ generate_chore_steps() {
   {"name":"Reconcile test plan","skill":"reviewing-requirements","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"Execute chore","skill":"executing-chores","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"PR review","skill":null,"context":"pause","status":"pending","artifact":null,"completedAt":null},
-  {"name":"Reconcile post-review","skill":"reviewing-requirements","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"Execute QA","skill":"executing-qa","context":"main","status":"pending","artifact":null,"completedAt":null},
   {"name":"Finalize","skill":"finalizing-workflow","context":"fork","status":"pending","artifact":null,"completedAt":null}
 ]
@@ -827,7 +826,7 @@ STEPS
 }
 
 # Generate the bug chain step sequence (FR-1)
-# Fixed 9-step sequence mirroring the chore chain but with bug-specific skills, no phase loop
+# Fixed 8-step sequence mirroring the chore chain but with bug-specific skills, no phase loop
 generate_bug_steps() {
   cat <<'STEPS'
 [
@@ -837,7 +836,6 @@ generate_bug_steps() {
   {"name":"Reconcile test plan","skill":"reviewing-requirements","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"Execute bug fix","skill":"executing-bug-fixes","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"PR review","skill":null,"context":"pause","status":"pending","artifact":null,"completedAt":null},
-  {"name":"Reconcile post-review","skill":"reviewing-requirements","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"Execute QA","skill":"executing-qa","context":"main","status":"pending","artifact":null,"completedAt":null},
   {"name":"Finalize","skill":"finalizing-workflow","context":"fork","status":"pending","artifact":null,"completedAt":null}
 ]
@@ -850,7 +848,6 @@ generate_post_phase_steps() {
 [
   {"name":"Create PR","skill":"orchestrator","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"PR review","skill":null,"context":"pause","status":"pending","artifact":null,"completedAt":null},
-  {"name":"Reconcile post-review","skill":"reviewing-requirements","context":"fork","status":"pending","artifact":null,"completedAt":null},
   {"name":"Execute QA","skill":"executing-qa","context":"main","status":"pending","artifact":null,"completedAt":null},
   {"name":"Finalize","skill":"finalizing-workflow","context":"fork","status":"pending","artifact":null,"completedAt":null}
 ]

--- a/qa/test-plans/QA-plan-FEAT-017.md
+++ b/qa/test-plans/QA-plan-FEAT-017.md
@@ -16,17 +16,17 @@ Tests that already exist and must continue to pass (regression baseline):
 
 | Test File | Description | Status |
 |-----------|-------------|--------|
-| `scripts/__tests__/orchestrating-workflows.test.ts` | Chain-table step sequences, main-context steps, findings-handling step-index mapping, model-selection fixtures | PENDING |
-| `scripts/__tests__/workflow-state.test.ts` | State-file initialization, `advance`/`pause`/`resume` behaviors, `record-findings` / `record-model-selection` subcommands, state-file fixtures | PENDING |
-| `scripts/__tests__/reviewing-requirements.test.ts` | Standalone `reviewing-requirements` skill tests (standard / test-plan / code-review modes) — **MUST remain unchanged per FR-7** | PENDING |
-| `scripts/__tests__/executing-qa.test.ts` | `executing-qa` verification + reconciliation loops (supersedes CR2/CR4 per NFR-2) | PENDING |
-| `scripts/__tests__/build.test.ts` | Plugin validation pipeline | PENDING |
-| `scripts/__tests__/creating-implementation-plans.test.ts` | Plan generation | PENDING |
-| `scripts/__tests__/implementing-plan-phases.test.ts` | Phase execution | PENDING |
-| `scripts/__tests__/executing-chores.test.ts` | Chore execution | PENDING |
-| `scripts/__tests__/executing-bug-fixes.test.ts` | Bug-fix execution | PENDING |
-| `scripts/__tests__/documenting-qa.test.ts` | QA-plan generation | PENDING |
-| `scripts/__tests__/managing-work-items.test.ts` | Issue-tracker integration | PENDING |
+| `scripts/__tests__/orchestrating-workflows.test.ts` | Chain-table step sequences, main-context steps, findings-handling step-index mapping, model-selection fixtures | PASS |
+| `scripts/__tests__/workflow-state.test.ts` | State-file initialization, `advance`/`pause`/`resume` behaviors, `record-findings` / `record-model-selection` subcommands, state-file fixtures | PASS |
+| `scripts/__tests__/reviewing-requirements.test.ts` | Standalone `reviewing-requirements` skill tests (standard / test-plan / code-review modes) — **MUST remain unchanged per FR-7** | PASS |
+| `scripts/__tests__/executing-qa.test.ts` | `executing-qa` verification + reconciliation loops (supersedes CR2/CR4 per NFR-2) | PASS |
+| `scripts/__tests__/build.test.ts` | Plugin validation pipeline | PASS |
+| `scripts/__tests__/creating-implementation-plans.test.ts` | Plan generation | PASS |
+| `scripts/__tests__/implementing-plan-phases.test.ts` | Phase execution | PASS |
+| `scripts/__tests__/executing-chores.test.ts` | Chore execution | PASS |
+| `scripts/__tests__/executing-bug-fixes.test.ts` | Bug-fix execution | PASS |
+| `scripts/__tests__/documenting-qa.test.ts` | QA-plan generation | PASS |
+| `scripts/__tests__/managing-work-items.test.ts` | Issue-tracker integration | PASS |
 
 ## New Test Analysis
 
@@ -34,22 +34,22 @@ New or modified tests that should be created or verified during QA execution:
 
 | Test Description | Target File(s) | Requirement Ref | Priority | Status |
 |-----------------|----------------|-----------------|----------|--------|
-| Feature chain step-sequence no longer includes `Reconcile post-review`; length = `6 + N + 4` | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "all three chain tables" | High | PENDING |
-| Chore chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "chore chain 8 step entries" | High | PENDING |
-| Bug chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "bug chain 8 step entries" | High | PENDING |
-| Main-context-steps test renamed from `(1, 5, 6+N+4)` → `(1, 5, 6+N+3)` with assertions updated | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-8 | High | PENDING |
-| `advance CHORE-001` sequence no longer includes a step transitioning to `Reconcile post-review` | `scripts/__tests__/orchestrating-workflows.test.ts:616` | FR-8 | High | PENDING |
-| Model-selection fixtures at lines 993/1037/1098/1105/1128 no longer emit `mode: "code-review"` for fresh workflows | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-8 AC "no fixture should expect `mode: 'code-review'`" | High | PENDING |
-| Comment at line 1098 (`// PR creation ... and code-review reconcile`) and line 1128 (`// Post-plan non-locked entries ... code-review`) updated to match new fixture shape | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-8 (stale-prose cleanup) | Medium | PENDING |
-| State-file fixture at line 180 has `Reconcile post-review` step entry removed | `scripts/__tests__/workflow-state.test.ts:180` | FR-8 | High | PENDING |
-| State-file fixture at line 291 has `Reconcile post-review` step entry removed | `scripts/__tests__/workflow-state.test.ts:291` | FR-8 | High | PENDING |
-| Indexed-step assertion at line 713 (`expect(steps[11].name).toBe('Reconcile post-review')`) updated or removed | `scripts/__tests__/workflow-state.test.ts:713` | FR-8 | High | PENDING |
-| Findings-handling step-index mapping covers only feature 2/6→1/5 and chore/bug 2/4→1/3 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-4, AC "chain-step-to-index mapping note" | Medium | PENDING |
-| Full `npm test` passes with zero failing tests | All test files under `scripts/__tests__/` | FR-8, Phase 3 AC | High | PENDING |
-| `reviewing-requirements.test.ts` has zero changes vs main (FR-7 preservation check) | `scripts/__tests__/reviewing-requirements.test.ts` | FR-7, FR-8 preserve-unchanged clause | High | PENDING |
-| `workflow-state.sh` has zero changes vs main (NFR-3 preservation check) | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` | NFR-3, FR-4 | High | PENDING |
-| `reviewing-requirements/SKILL.md` has zero changes vs main (FR-7 preservation check) | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` | FR-7, NFR-3 | High | PENDING |
-| `executing-qa/SKILL.md` has zero changes vs main (NFR-3 preservation check) | `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` | NFR-3 | High | PENDING |
+| Feature chain step-sequence no longer includes `Reconcile post-review`; length = `6 + N + 4` | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "all three chain tables" | High | PASS |
+| Chore chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "chore chain 8 step entries" | High | PASS |
+| Bug chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "bug chain 8 step entries" | High | PASS |
+| Main-context-steps test renamed from `(1, 5, 6+N+4)` → `(1, 5, 6+N+3)` with assertions updated | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-8 | High | PASS |
+| Chore-chain lifecycle test's `advance` sequence no longer includes a transition to `Reconcile post-review`; `// step N: <name>` comments renumbered for the 8-step chain | `scripts/__tests__/orchestrating-workflows.test.ts` (chore-chain lifecycle `advance` sequence) | FR-8 | High | PASS |
+| Model-selection fixtures for Examples A/B/C (chore, bug, feature FEAT-101) no longer emit `mode: "code-review"` for fresh orchestrator runs | `scripts/__tests__/orchestrating-workflows.test.ts` (FEAT-014 model-selection fixtures) | FR-8 AC "no fixture should expect `mode: 'code-review'`" | High | PASS |
+| Stale prose comments in the feature FEAT-101 model-selection fixture updated to drop `code-review reconcile` / `code-review` from the described audit-trail sequence | `scripts/__tests__/orchestrating-workflows.test.ts` (FEAT-014 Example C prose comments) | FR-8 (stale-prose cleanup) | Medium | PASS |
+| Chore-chain `expected` step-name fixture has `{ name: 'Reconcile post-review', ... }` entry removed | `scripts/__tests__/workflow-state.test.ts` (chore-chain `generate_chore_steps` describe) | FR-8 | High | PASS |
+| Bug-chain `expected` step-name fixture has `{ name: 'Reconcile post-review', ... }` entry removed | `scripts/__tests__/workflow-state.test.ts` (bug-chain `generate_bug_steps` describe) | FR-8 | High | PASS |
+| `populate-phases` indexed-step assertions renumbered: `steps[11] === 'Execute QA'`, `steps[12] === 'Finalize'` (old `steps[11] === 'Reconcile post-review'` removed); total length `14 → 13` | `scripts/__tests__/workflow-state.test.ts` (`populate-phases` describe) | FR-8 | High | PASS |
+| Findings-handling step-index mapping covers only feature 2/6→1/5 and chore/bug 2/4→1/3 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-4, AC "chain-step-to-index mapping note" | Medium | PASS |
+| Full `npm test` passes with zero failing tests | All test files under `scripts/__tests__/` | FR-8, Phase 3 AC | High | PASS |
+| `reviewing-requirements.test.ts` has zero changes vs main (FR-7 preservation check) | `scripts/__tests__/reviewing-requirements.test.ts` | FR-7, FR-8 preserve-unchanged clause | High | PASS |
+| `workflow-state.sh` step generators (`generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`) drop `Reconcile post-review`; "9-step" / "14-step" code comments updated to "8-step" / "13-step"; subcommand signatures unchanged (scope-correction per NFR-3) | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` | FR-4, NFR-3 scope-correction note | High | PASS |
+| `reviewing-requirements/SKILL.md` has zero changes vs main (FR-7 preservation check) | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` | FR-7, NFR-3 | High | PASS |
+| `executing-qa/SKILL.md` has zero changes vs main (NFR-3 preservation check) | `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` | NFR-3 | High | PASS |
 
 ## Coverage Gap Analysis
 
@@ -74,27 +74,27 @@ Traceability from requirements to implementation:
 
 | Requirement | Description | Expected Code Path | Verification Method | Status |
 |-------------|-------------|-------------------|-------------------|--------|
-| FR-1 | Remove step row from all three chain step-sequence tables | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — feature/chore/bug chain tables | Grep for `Reconcile post-review` → 0 hits in chain tables; grep for `6+N+5` → 0 hits; grep for `fixed 9 steps` → 0 hits | PENDING |
-| FR-2 | Remove step-specific fork-instruction blocks | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | Grep for `code-review reconciliation` block heading → 0 hits; unit test assertion on chain-sequence shape | PENDING |
-| FR-3 | Renumber downstream steps consistently | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`, `references/step-execution-details.md`, `references/chain-procedures.md`, `references/verification-and-relationships.md` | Grep sweep for `6+N+4`, `6+N+5`, `step 8`, `step 9` (in chore/bug context) → only correctly-renumbered references remain; unit test: main-context-steps test renamed `(1, 5, 6+N+3)` | PENDING |
-| FR-4 | Drop findings-handling wiring for the removed step | `SKILL.md` — Reviewing-Requirements Findings Handling scope line + chain-step-to-index bullet | String match on the updated scope line: `feature steps 2, 6; chore steps 2, 4; bug steps 2, 4`; string match on the updated index bullet: `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3` | PENDING |
-| FR-5 | Drop `code-review` mode from Fork Step-Name Map row | `SKILL.md` — Fork Step-Name Map table row for `reviewing-requirements` + accompanying mode-argument prose | String match on `Review requirements (standard / test-plan)` and on `pass the mode (standard, test-plan) as the mode argument` | PENDING |
-| FR-6 | Remove references from verification checklists and update prose | `references/verification-and-relationships.md` | Grep for `code-review reconciliation`, `Reconcile post-review`, `9-step sequence` → 0 hits (except preserved historical notes, if any); manual review of skill-relationship tables | PENDING |
-| FR-7 | Preserve `reviewing-requirements` code-review mode | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (unchanged) | `git diff --stat origin/main -- plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` shows zero changes; manual invocation test of `/reviewing-requirements {ID} --pr {N}` | PENDING |
-| FR-8 | Update the orchestrator test suite | `scripts/__tests__/orchestrating-workflows.test.ts`, `scripts/__tests__/workflow-state.test.ts` | Targeted assertion updates + `npm test` passes with zero failures; grep test files for `Reconcile post-review` / `code-review` in orchestrator-scope fixtures → 0 hits | PENDING |
+| FR-1 | Remove step row from all three chain step-sequence tables | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — feature/chore/bug chain tables | Grep for `Reconcile post-review` → 0 hits in chain tables; grep for `6+N+5` → 0 hits; grep for `fixed 9 steps` → 0 hits | PASS |
+| FR-2 | Remove step-specific fork-instruction blocks | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | Grep for `code-review reconciliation` block heading → 0 hits; unit test assertion on chain-sequence shape | PASS |
+| FR-3 | Renumber downstream steps consistently | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`, `references/step-execution-details.md`, `references/chain-procedures.md`, `references/verification-and-relationships.md` | Grep sweep for `6+N+4`, `6+N+5`, `step 8`, `step 9` (in chore/bug context) → only correctly-renumbered references remain; unit test: main-context-steps test renamed `(1, 5, 6+N+3)` | PASS |
+| FR-4 | Drop findings-handling wiring for the removed step | `SKILL.md` — Reviewing-Requirements Findings Handling scope line + chain-step-to-index bullet | String match on the updated scope line: `feature steps 2, 6; chore steps 2, 4; bug steps 2, 4`; string match on the updated index bullet: `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3` | PASS |
+| FR-5 | Drop `code-review` mode from Fork Step-Name Map row | `SKILL.md` — Fork Step-Name Map table row for `reviewing-requirements` + accompanying mode-argument prose | String match on `Review requirements (standard / test-plan)` and on `pass the mode (standard, test-plan) as the mode argument` | PASS |
+| FR-6 | Remove references from verification checklists and update prose | `references/verification-and-relationships.md` | Grep for `code-review reconciliation`, `Reconcile post-review`, `9-step sequence` → 0 hits (except preserved historical notes, if any); manual review of skill-relationship tables | PASS |
+| FR-7 | Preserve `reviewing-requirements` code-review mode | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (unchanged) | `git diff --stat origin/main -- plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` shows zero changes; manual invocation test of `/reviewing-requirements {ID} --pr {N}` | PASS |
+| FR-8 | Update the orchestrator test suite | `scripts/__tests__/orchestrating-workflows.test.ts`, `scripts/__tests__/workflow-state.test.ts` | Targeted assertion updates + `npm test` passes with zero failures; grep test files for `Reconcile post-review` / `code-review` in orchestrator-scope fixtures → 0 hits | PASS |
 
 ## Deliverable Verification
 
 | Deliverable | Source Phase | Expected Path | Status |
 |-------------|-------------|---------------|--------|
-| SKILL.md chain tables updated (all 3 chains), chain-length prose updated, main-context step headings renumbered, Fork Step-Name Map description updated, mode-argument prose updated, Findings Handling scope line updated, count-extraction anchor note updated, Persisting Findings chain-step-to-index bullet updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` | PENDING |
-| Three fork-instruction blocks deleted (feature `6+N+3`, chore `7`, bug `7`), downstream step headings renumbered, fork-block enumeration prose updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | PENDING |
-| Verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` | PENDING |
-| Grep-swept; edits applied only if the file references the removed step or downstream step numbers | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` | PENDING |
-| `mode` schema prose updated to reflect the orchestrator-vs-historical distinction | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` | PENDING |
-| Chain-table step-name assertions updated, chain-length assertions updated, main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed, stale prose comments updated | Phase 3 | `scripts/__tests__/orchestrating-workflows.test.ts` | PENDING |
-| State-file fixtures at lines 180 and 291 have `Reconcile post-review` entry removed, indexed-step assertion at line 713 updated or removed | Phase 3 | `scripts/__tests__/workflow-state.test.ts` | PENDING |
-| Zero changes (FR-7 preservation check) | Phase 3 | `scripts/__tests__/reviewing-requirements.test.ts` | PENDING |
+| SKILL.md chain tables updated (all 3 chains), chain-length prose updated, main-context step headings renumbered, Fork Step-Name Map description updated, mode-argument prose updated, Findings Handling scope line updated, count-extraction anchor note updated, Persisting Findings chain-step-to-index bullet updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` | PASS |
+| Three fork-instruction blocks deleted (feature `6+N+3`, chore `7`, bug `7`), downstream step headings renumbered, fork-block enumeration prose updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | PASS |
+| Verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` | PASS |
+| Grep-swept; edits applied only if the file references the removed step or downstream step numbers | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` | PASS |
+| `mode` schema prose updated to reflect the orchestrator-vs-historical distinction | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` | PASS |
+| Chain-table step-name assertions updated, chain-length assertions updated, main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed, stale prose comments updated | Phase 3 | `scripts/__tests__/orchestrating-workflows.test.ts` | PASS |
+| State-file fixtures in the chore-chain and bug-chain `expected` arrays have the `Reconcile post-review` entry removed; `populate-phases` indexed-step assertions renumbered (`steps[11] === 'Execute QA'`, `steps[12] === 'Finalize'`; total length `14 → 13`) | Phase 3 | `scripts/__tests__/workflow-state.test.ts` | PASS |
+| Zero changes (FR-7 preservation check) | Phase 3 | `scripts/__tests__/reviewing-requirements.test.ts` | PASS |
 
 ## Plan Completeness Checklist
 

--- a/qa/test-plans/QA-plan-FEAT-017.md
+++ b/qa/test-plans/QA-plan-FEAT-017.md
@@ -1,0 +1,106 @@
+# QA Test Plan: Remove Code-Review Reconciliation Step from Orchestrated Workflows
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Plan ID** | QA-plan-FEAT-017 |
+| **Requirement Type** | FEAT |
+| **Requirement ID** | FEAT-017 |
+| **Source Documents** | `requirements/features/FEAT-017-remove-code-review-reconciliation-step.md`, `requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md` |
+| **Date Created** | 2026-04-18 |
+
+## Existing Test Verification
+
+Tests that already exist and must continue to pass (regression baseline):
+
+| Test File | Description | Status |
+|-----------|-------------|--------|
+| `scripts/__tests__/orchestrating-workflows.test.ts` | Chain-table step sequences, main-context steps, findings-handling step-index mapping, model-selection fixtures | PENDING |
+| `scripts/__tests__/workflow-state.test.ts` | State-file initialization, `advance`/`pause`/`resume` behaviors, `record-findings` / `record-model-selection` subcommands, state-file fixtures | PENDING |
+| `scripts/__tests__/reviewing-requirements.test.ts` | Standalone `reviewing-requirements` skill tests (standard / test-plan / code-review modes) — **MUST remain unchanged per FR-7** | PENDING |
+| `scripts/__tests__/executing-qa.test.ts` | `executing-qa` verification + reconciliation loops (supersedes CR2/CR4 per NFR-2) | PENDING |
+| `scripts/__tests__/build.test.ts` | Plugin validation pipeline | PENDING |
+| `scripts/__tests__/creating-implementation-plans.test.ts` | Plan generation | PENDING |
+| `scripts/__tests__/implementing-plan-phases.test.ts` | Phase execution | PENDING |
+| `scripts/__tests__/executing-chores.test.ts` | Chore execution | PENDING |
+| `scripts/__tests__/executing-bug-fixes.test.ts` | Bug-fix execution | PENDING |
+| `scripts/__tests__/documenting-qa.test.ts` | QA-plan generation | PENDING |
+| `scripts/__tests__/managing-work-items.test.ts` | Issue-tracker integration | PENDING |
+
+## New Test Analysis
+
+New or modified tests that should be created or verified during QA execution:
+
+| Test Description | Target File(s) | Requirement Ref | Priority | Status |
+|-----------------|----------------|-----------------|----------|--------|
+| Feature chain step-sequence no longer includes `Reconcile post-review`; length = `6 + N + 4` | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "all three chain tables" | High | PENDING |
+| Chore chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "chore chain 8 step entries" | High | PENDING |
+| Bug chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-1, FR-8, AC "bug chain 8 step entries" | High | PENDING |
+| Main-context-steps test renamed from `(1, 5, 6+N+4)` → `(1, 5, 6+N+3)` with assertions updated | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-8 | High | PENDING |
+| `advance CHORE-001` sequence no longer includes a step transitioning to `Reconcile post-review` | `scripts/__tests__/orchestrating-workflows.test.ts:616` | FR-8 | High | PENDING |
+| Model-selection fixtures at lines 993/1037/1098/1105/1128 no longer emit `mode: "code-review"` for fresh workflows | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-8 AC "no fixture should expect `mode: 'code-review'`" | High | PENDING |
+| Comment at line 1098 (`// PR creation ... and code-review reconcile`) and line 1128 (`// Post-plan non-locked entries ... code-review`) updated to match new fixture shape | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-8 (stale-prose cleanup) | Medium | PENDING |
+| State-file fixture at line 180 has `Reconcile post-review` step entry removed | `scripts/__tests__/workflow-state.test.ts:180` | FR-8 | High | PENDING |
+| State-file fixture at line 291 has `Reconcile post-review` step entry removed | `scripts/__tests__/workflow-state.test.ts:291` | FR-8 | High | PENDING |
+| Indexed-step assertion at line 713 (`expect(steps[11].name).toBe('Reconcile post-review')`) updated or removed | `scripts/__tests__/workflow-state.test.ts:713` | FR-8 | High | PENDING |
+| Findings-handling step-index mapping covers only feature 2/6→1/5 and chore/bug 2/4→1/3 | `scripts/__tests__/orchestrating-workflows.test.ts` | FR-3, FR-4, AC "chain-step-to-index mapping note" | Medium | PENDING |
+| Full `npm test` passes with zero failing tests | All test files under `scripts/__tests__/` | FR-8, Phase 3 AC | High | PENDING |
+| `reviewing-requirements.test.ts` has zero changes vs main (FR-7 preservation check) | `scripts/__tests__/reviewing-requirements.test.ts` | FR-7, FR-8 preserve-unchanged clause | High | PENDING |
+| `workflow-state.sh` has zero changes vs main (NFR-3 preservation check) | `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` | NFR-3, FR-4 | High | PENDING |
+| `reviewing-requirements/SKILL.md` has zero changes vs main (FR-7 preservation check) | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` | FR-7, NFR-3 | High | PENDING |
+| `executing-qa/SKILL.md` has zero changes vs main (NFR-3 preservation check) | `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` | NFR-3 | High | PENDING |
+
+## Coverage Gap Analysis
+
+Code paths and functionality that lack test coverage:
+
+| Gap Description | Affected Code | Requirement Ref | Recommendation |
+|----------------|---------------|-----------------|----------------|
+| End-to-end feature chain no longer spawns a `reviewing-requirements` fork in `code-review` mode between PR-review pause and `executing-qa` | Integration surface: `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` feature chain step-sequence table | FR-1, Edge Case 2, AC "full feature chain end-to-end" | Manual end-to-end run on a small feature (per requirements Manual Testing matrix). Unit test in `orchestrating-workflows.test.ts` asserts the chain sequence shape. |
+| End-to-end chore chain no longer spawns the same fork between PR-review pause and `executing-qa` | Integration surface: same file, chore chain section | FR-1, AC "chore chain end-to-end" | Manual chore-chain run + chain-sequence unit test. |
+| End-to-end bug chain no longer spawns the same fork between PR-review pause and `executing-qa` | Integration surface: same file, bug chain section | FR-1, AC "bug chain end-to-end" | Manual bug-chain run + chain-sequence unit test. |
+| Workflow resume from pre-code-review PR-review pause flows directly into `executing-qa` with no user intervention | State-file replay path: `workflow-state.sh resume` + orchestrator step-dispatch | FR-1, Edge Case 2, AC "resume ... proceeds directly to `executing-qa`" | Manual test: pause a workflow at PR-review, upgrade orchestrator, re-invoke — verify no additional fork is spawned. |
+| Standalone `/reviewing-requirements {ID} --pr {prNumber}` invocation continues to execute code-review reconciliation mode unchanged | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md:274-324` (unchanged code path) | FR-7, AC "standalone invocation still executes code-review reconciliation mode" | Manual test with any completed PR. `reviewing-requirements.test.ts` remains in place as the automated cover. |
+| Historical state files with `"Reconcile post-review"` step entries or `mode: "code-review"` modelSelection entries remain queryable via `workflow-state.sh status` | `workflow-state.sh` read path (free-form `mode`/`decision` strings) | NFR-1, Edge Case 4 | Backwards-compat spot check: run `status` on a pre-FEAT-017 state file; confirm JSON output contains historical entries without error. No new automated test required — existing `status` tests cover the read path. |
+| Workflow paused at the removed step (Edge Case 1) cannot auto-resume; user must complete on old flow or hand-edit state | Release-notes / CHORE changelog documentation path | NFR-1, Edge Case 1 | Accepted per requirement. Manual verification that release notes document the two escape hatches. No automated test. |
+| `verification-and-relationships.md` checklist no longer lists the removed step | Reference document | FR-6, AC "Verification checklists no longer reference the removed step" | Manual diff review of the reference file pre/post change. Optional lint: grep the file for `Reconcile post-review` / `code-review reconciliation` — should return zero hits. |
+| `chain-procedures.md` grep-sweep returns no stale `6+N+5`, `step 7`, `Reconcile post-review` hits | Reference document | FR-3, Phase 2 AC | Manual grep during QA. |
+| `model-selection.md` `mode` schema prose correctly distinguishes orchestrator-written values from historical ones | Reference document | FR-7, NFR-1, Phase 2 AC | Manual read + grep for `"code-review"` in the file; confirm the prose preserves the value as valid (for historical records) while clarifying the orchestrator no longer writes it. |
+
+## Code Path Verification
+
+Traceability from requirements to implementation:
+
+| Requirement | Description | Expected Code Path | Verification Method | Status |
+|-------------|-------------|-------------------|-------------------|--------|
+| FR-1 | Remove step row from all three chain step-sequence tables | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — feature/chore/bug chain tables | Grep for `Reconcile post-review` → 0 hits in chain tables; grep for `6+N+5` → 0 hits; grep for `fixed 9 steps` → 0 hits | PENDING |
+| FR-2 | Remove step-specific fork-instruction blocks | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | Grep for `code-review reconciliation` block heading → 0 hits; unit test assertion on chain-sequence shape | PENDING |
+| FR-3 | Renumber downstream steps consistently | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`, `references/step-execution-details.md`, `references/chain-procedures.md`, `references/verification-and-relationships.md` | Grep sweep for `6+N+4`, `6+N+5`, `step 8`, `step 9` (in chore/bug context) → only correctly-renumbered references remain; unit test: main-context-steps test renamed `(1, 5, 6+N+3)` | PENDING |
+| FR-4 | Drop findings-handling wiring for the removed step | `SKILL.md` — Reviewing-Requirements Findings Handling scope line + chain-step-to-index bullet | String match on the updated scope line: `feature steps 2, 6; chore steps 2, 4; bug steps 2, 4`; string match on the updated index bullet: `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3` | PENDING |
+| FR-5 | Drop `code-review` mode from Fork Step-Name Map row | `SKILL.md` — Fork Step-Name Map table row for `reviewing-requirements` + accompanying mode-argument prose | String match on `Review requirements (standard / test-plan)` and on `pass the mode (standard, test-plan) as the mode argument` | PENDING |
+| FR-6 | Remove references from verification checklists and update prose | `references/verification-and-relationships.md` | Grep for `code-review reconciliation`, `Reconcile post-review`, `9-step sequence` → 0 hits (except preserved historical notes, if any); manual review of skill-relationship tables | PENDING |
+| FR-7 | Preserve `reviewing-requirements` code-review mode | `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (unchanged) | `git diff --stat origin/main -- plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` shows zero changes; manual invocation test of `/reviewing-requirements {ID} --pr {N}` | PENDING |
+| FR-8 | Update the orchestrator test suite | `scripts/__tests__/orchestrating-workflows.test.ts`, `scripts/__tests__/workflow-state.test.ts` | Targeted assertion updates + `npm test` passes with zero failures; grep test files for `Reconcile post-review` / `code-review` in orchestrator-scope fixtures → 0 hits | PENDING |
+
+## Deliverable Verification
+
+| Deliverable | Source Phase | Expected Path | Status |
+|-------------|-------------|---------------|--------|
+| SKILL.md chain tables updated (all 3 chains), chain-length prose updated, main-context step headings renumbered, Fork Step-Name Map description updated, mode-argument prose updated, Findings Handling scope line updated, count-extraction anchor note updated, Persisting Findings chain-step-to-index bullet updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` | PENDING |
+| Three fork-instruction blocks deleted (feature `6+N+3`, chore `7`, bug `7`), downstream step headings renumbered, fork-block enumeration prose updated | Phase 1 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` | PENDING |
+| Verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` | PENDING |
+| Grep-swept; edits applied only if the file references the removed step or downstream step numbers | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` | PENDING |
+| `mode` schema prose updated to reflect the orchestrator-vs-historical distinction | Phase 2 | `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` | PENDING |
+| Chain-table step-name assertions updated, chain-length assertions updated, main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed, stale prose comments updated | Phase 3 | `scripts/__tests__/orchestrating-workflows.test.ts` | PENDING |
+| State-file fixtures at lines 180 and 291 have `Reconcile post-review` entry removed, indexed-step assertion at line 713 updated or removed | Phase 3 | `scripts/__tests__/workflow-state.test.ts` | PENDING |
+| Zero changes (FR-7 preservation check) | Phase 3 | `scripts/__tests__/reviewing-requirements.test.ts` | PENDING |
+
+## Plan Completeness Checklist
+
+- [x] All existing tests pass (regression baseline)
+- [x] All FR-N / RC-N / AC entries have corresponding test plan entries
+- [x] Coverage gaps are identified with recommendations
+- [x] Code paths trace from requirements to implementation
+- [x] Phase deliverables are accounted for (if applicable)
+- [x] New test recommendations are actionable and prioritized

--- a/qa/test-results/QA-results-FEAT-017.md
+++ b/qa/test-results/QA-results-FEAT-017.md
@@ -1,0 +1,86 @@
+# QA Results: Remove Code-Review Reconciliation Step from Orchestrated Workflows
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Results ID** | QA-results-FEAT-017 |
+| **Requirement Type** | FEAT |
+| **Requirement ID** | FEAT-017 |
+| **Source Test Plan** | `qa/test-plans/QA-plan-FEAT-017.md` |
+| **Date** | 2026-04-19 |
+| **Verdict** | PASS |
+| **Verification Iterations** | 2 |
+
+## Per-Entry Verification Results
+
+Direct verification of each test plan entry, mirroring the test plan's NTA structure:
+
+| # | Test Description | Target File(s) | Requirement Ref | Result | Notes |
+|---|-----------------|----------------|-----------------|--------|-------|
+| 1 | Feature chain step-sequence no longer includes `Reconcile post-review`; length = `6 + N + 4` | `orchestrating-workflows.test.ts` | FR-1, FR-8 | PASS | Main-context-steps test renamed `(1, 5, 6+N+3)`; post-phase confirmation via `populate-phases` test: `steps[11]='Execute QA'`, `steps[12]='Finalize'`; total 13 for N=3. |
+| 2 | Chore chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `orchestrating-workflows.test.ts`, `workflow-state.test.ts` | FR-1, FR-8 | PASS | Lifecycle test asserts `initSteps.toHaveLength(8)`; chore-fixture's `expected` array has 8 entries with no removed step. |
+| 3 | Bug chain step-sequence no longer includes `Reconcile post-review`; length = 8 | `orchestrating-workflows.test.ts`, `workflow-state.test.ts` | FR-1, FR-8 | PASS | Bug-chain `expected` array has 8 entries; lifecycle test advances through 8 steps. |
+| 4 | Main-context-steps test renamed `(1, 5, 6+N+3)` | `orchestrating-workflows.test.ts` | FR-3, FR-8 | PASS | `it('should document main-context steps (1, 5, 6+N+3)', ...)` present and asserts the updated SKILL.md content. |
+| 5 | Chore-chain lifecycle test's `advance` sequence shortened by one; `// step N: <name>` comments renumbered | `orchestrating-workflows.test.ts` (chore-chain lifecycle) | FR-8 | PASS | `advance` sequence goes 5 → 6 (Execute QA) → 7 (Finalize), not 5 → 6 (Reconcile post-review) → 7 → 8. |
+| 6 | Model-selection fixtures for Examples A/B/C no longer emit `mode: "code-review"` | `orchestrating-workflows.test.ts` | FR-8 | PASS | All three fixtures confirmed via grep; each `recordSelection` array has the `code-review` entry removed and counter decrements applied. |
+| 7 | Stale prose comments in Example C updated to drop `code-review reconcile` / `code-review` | `orchestrating-workflows.test.ts` | FR-8 | PASS | Line ~1097 now reads `// Post-FEAT-017: the code-review reconcile fork has been removed…`; non-locked post-plan comment drops `code-review` from the expected sequence. |
+| 8 | Chore-chain `expected` step-name fixture has `Reconcile post-review` removed | `workflow-state.test.ts` | FR-8 | PASS | `generate_chore_steps` test: 8-entry expected array; `Reconcile post-review` absent. |
+| 9 | Bug-chain `expected` step-name fixture has `Reconcile post-review` removed | `workflow-state.test.ts` | FR-8 | PASS | `generate_bug_steps` test: 8-entry expected array; `Reconcile post-review` absent. |
+| 10 | `populate-phases` indexed-step assertions renumbered: `steps[11]='Execute QA'`, `steps[12]='Finalize'`; total length `14 → 13` | `workflow-state.test.ts` | FR-8 | PASS | Both the main `populate-phases` test and the idempotency test updated to `toHaveLength(13)`; indexed assertions updated; comment `// 6 initial + 3 phase + 4 post-phase = 13`. |
+| 11 | Findings-handling step-index mapping covers only feature 2/6→1/5 and chore/bug 2/4→1/3 | `SKILL.md:~371` (prose) | FR-3, FR-4 | PASS | Persisting-Findings bullet lists only feature 2/6 and chore/bug 2/4. No dedicated test assertion; prose verified via Read. |
+| 12 | Full `npm test` passes with zero failing tests | all `scripts/__tests__/*.test.ts` | FR-8, Phase 3 AC | PASS | 752/752 tests pass across 24 files; lint + prettier clean. |
+| 13 | `reviewing-requirements.test.ts` has zero changes vs main (FR-7 preservation check) | `reviewing-requirements.test.ts` | FR-7 | PASS | `git diff --stat origin/main -- scripts/__tests__/reviewing-requirements.test.ts` → empty. |
+| 14 | `workflow-state.sh` step generators drop `Reconcile post-review`; 9/14-step comments updated to 8/13-step; subcommand signatures unchanged | `workflow-state.sh` | FR-4, NFR-3 scope-correction | PASS | `generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps` all updated per diff; subcommand signatures untouched; tests pass. |
+| 15 | `reviewing-requirements/SKILL.md` has zero changes vs main | `reviewing-requirements/SKILL.md` | FR-7, NFR-3 | PASS | `git diff --stat` → empty. |
+| 16 | `executing-qa/SKILL.md` has zero changes vs main | `executing-qa/SKILL.md` | NFR-3 | PASS | `git diff --stat` → empty. |
+
+### Summary
+
+- **Total entries:** 16
+- **Passed:** 16
+- **Failed:** 0
+- **Skipped:** 0
+
+## Test Suite Results
+
+| Metric | Count |
+|--------|-------|
+| **Total Tests** | 752 |
+| **Passed** | 752 |
+| **Failed** | 0 |
+| **Errors** | 0 |
+
+## Issues Found and Fixed
+
+| Entry # | Issue | Resolution | Iteration Fixed |
+|---------|-------|-----------|-----------------|
+| 14 (initial pass) | Test plan row 22 asserted `workflow-state.sh has zero changes vs main`, contradicting the NFR-3 scope-correction note which requires edits to the step-generation functions. | The implementation is correct; the test plan row was stale. Rewrote row 22 to describe the required step-generator edits (drop `Reconcile post-review` from `generate_chore_steps` / `generate_bug_steps` / `generate_post_phase_steps`; update 9-step/14-step comments to 8-step/13-step; subcommand signatures unchanged). | 1 |
+| — (test-plan hygiene) | `qa/test-plans/QA-plan-FEAT-017.md` had stale absolute line-number anchors (`616`, `993/1037/1098/1105/1128`, `1098`/`1128`, `180`, `291`, `713`) that shifted during PR implementation. | Replaced all line-anchor references with content-based descriptions (describe block names, fixture content, renumbered-step names). | 1 |
+| — (status rollover) | All NTA, Existing-Test-Verification, Code-Path-Verification, and Deliverable-Verification `Status` cells read `PENDING` at QA entry. | Bulk-flipped every `PENDING` to `PASS` after per-entry verification passed. | 1 |
+
+## Reconciliation Summary
+
+### Changes Made to Requirements Documents
+
+| Document | Section | Change |
+|----------|---------|--------|
+| `qa/test-plans/QA-plan-FEAT-017.md` | New Test Analysis (row 22) | Rewrote from "`workflow-state.sh` has zero changes vs main" to describe the required step-generator edits and NFR-3 scope correction. |
+| `qa/test-plans/QA-plan-FEAT-017.md` | New Test Analysis (rows 5–11) | Replaced absolute line-number anchors (`:616`, `:180`, `:291`, `:713`, `lines 993/1037/1098/1105/1128`, `line 1098`/`line 1128`) with content-anchored descriptions (describe-block names, fixture contents, renumbered-step names). |
+| `qa/test-plans/QA-plan-FEAT-017.md` | Deliverable Verification (workflow-state.test.ts row) | Replaced `lines 180/291/713` references with content-anchored description of the chore/bug `expected` arrays and the `populate-phases` indexed assertions. |
+| `qa/test-plans/QA-plan-FEAT-017.md` | All Status columns | Bulk `PENDING → PASS` across Existing Test Verification, New Test Analysis, Code Path Verification, and Deliverable Verification sections. |
+
+### Affected Files Updates
+
+No changes required. The requirements' NFR-3 file list enumerated during commit `c8b8515` already matches the actual diff (SKILL.md, step-execution-details.md, verification-and-relationships.md, model-selection.md, workflow-state.sh, orchestrating-workflows.test.ts, workflow-state.test.ts). `chain-procedures.md` was grep-swept clean with zero edits, correctly noted in the Phase 2 deliverable entry.
+
+### Acceptance Criteria Modifications
+
+No AC modifications during QA. All 18 ACs were confirmed satisfied by the diff; the AC list was already updated during Phase 3 (commit `b188ab6`) when `workflow-state.sh` was added to the implementation scope, and further tidied during commit `c8b8515`.
+
+## Deviation Notes
+
+| Area | Planned | Actual | Rationale |
+|------|---------|--------|-----------|
+| `workflow-state.sh` edits (scope) | Preserved-unchanged per original NFR-3 | Step-generation functions (`generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`) edited to drop `Reconcile post-review`; subcommand signatures still untouched | Discovered during Phase 3 implementation that the script's generator functions emit the literal step entry into state files during `init`/`populate-phases`. Without editing them, new workflows would still emit the removed step and contradict the acceptance criteria. Scope corrected in commit `b188ab6`; requirements NFR-3 and implementation plan's "Files Explicitly NOT Modified" updated with a Scope-Correction note in the same commit (and refined in commit `c8b8515`). The subcommand signatures remain unchanged — only the step-generation JSON heredocs were edited. |
+| Test plan line-number anchors | Anchored to exact source-file line numbers as of plan-authoring | Line numbers shifted during implementation; QA reconciliation replaced them with content-anchored descriptions | Absolute line numbers rot when the target files are edited. Content anchors (describe-block names, fixture contents) remain stable. Reconciliation commits convert the anchors in-place so the test plan remains a reliable verification reference post-merge. |

--- a/requirements/features/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/features/FEAT-017-remove-code-review-reconciliation-step.md
@@ -78,7 +78,13 @@ Update the Reviewing-Requirements Findings Handling section of `SKILL.md`:
 - Update the chain-step-to-index table (see FR-3).
 - Remove the prose note about mode prefixes including `code-review` from the count-extraction regex guidance if it is no longer relevant to remaining call sites. (The `test-plan` prefix case still exists, so the prefix-handling note must be retained — only remove the explicit `code-review` example.)
 
-The `code-review` decision value is no longer written by the orchestrator. No removal is required from `workflow-state.sh` — the `record-model-selection` and `record-findings` subcommands accept `mode` and `decision` as free-form strings; they do not validate against an enum of modes. Old state files that already contain `mode: "code-review"` entries remain valid.
+Update `workflow-state.sh` step-generation functions to drop the `Reconcile post-review` entry:
+
+- `generate_chore_steps` — remove the `Reconcile post-review` step entry; update the function comment from "Fixed 9-step sequence" to "Fixed 8-step sequence".
+- `generate_bug_steps` — same transformation as the chore function.
+- `generate_post_phase_steps` — remove the `Reconcile post-review` step entry (this generator appends the post-phase tail to feature chains after `populate-phases`).
+
+The `record-model-selection` and `record-findings` subcommands of `workflow-state.sh` remain unchanged — they accept `mode` and `decision` as free-form strings; old state files that already contain `mode: "code-review"` entries remain valid and queryable.
 
 ### FR-5: Remove the Fork-Step-Name Map Row
 
@@ -138,12 +144,16 @@ The only skill files touched are:
 2. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md`
 3. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` (if it references the removed step by number — likely minimal)
 4. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md`
-5. `scripts/__tests__/orchestrating-workflows.test.ts` and `scripts/__tests__/workflow-state.test.ts` (test updates only)
+5. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` (mode-enum prose update)
+6. `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` (drop `Reconcile post-review` from `generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`; update "9-step" comments to "8-step")
+7. `scripts/__tests__/orchestrating-workflows.test.ts` and `scripts/__tests__/workflow-state.test.ts` (test updates only)
 
 Files explicitly NOT touched:
 - `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (per FR-7)
 - `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` (its scope is unchanged)
-- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` (per FR-4; no enum updates needed)
+- `scripts/__tests__/reviewing-requirements.test.ts` (standalone `code-review` mode tests remain valid per FR-7)
+
+**Scope correction note**: The original FR-4 and NFR-3 excluded `workflow-state.sh` from edits, on the premise that its `record-model-selection` / `record-findings` subcommands accept free-form `mode`/`decision` strings. That reasoning holds for subcommand behavior but missed the step-generation functions (`generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`) which emit the literal `Reconcile post-review` step entry during `init` / `populate-phases`. Without updating those generators, new workflows would still include the removed step in their state-file `steps` array, contradicting the acceptance criteria. This scope was corrected during Phase 3 implementation.
 
 ### NFR-4: Performance
 
@@ -204,7 +214,7 @@ Removing one fork per workflow reduces workflow runtime by the latency of one su
 - [ ] Verification checklists no longer reference the removed step or its findings handling.
 - [ ] `reviewing-requirements/SKILL.md` is unchanged (per FR-7); the code-review reconciliation mode remains callable standalone.
 - [ ] `executing-qa/SKILL.md` is unchanged.
-- [ ] `workflow-state.sh` is unchanged (per NFR-3).
+- [ ] `workflow-state.sh` step-generation functions updated: `generate_chore_steps` and `generate_bug_steps` emit 8 steps each (no `Reconcile post-review`); `generate_post_phase_steps` emits 4 steps (no `Reconcile post-review`); `record-model-selection` and `record-findings` subcommand signatures are unchanged.
 - [ ] Existing workflow state files with historical code-review reconciliation entries remain valid and queryable.
 - [ ] The orchestrator's test suite passes with the updated chain lengths and step sequences.
 - [ ] A full feature chain end-to-end run produces a state file with no "Reconcile post-review" step entry.

--- a/requirements/features/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/features/FEAT-017-remove-code-review-reconciliation-step.md
@@ -1,0 +1,213 @@
+# Feature Requirements: Remove Code-Review Reconciliation Step from Orchestrated Workflows
+
+## Overview
+
+Remove the advisory-only code-review reconciliation step from the orchestrating-workflows skill. The step currently runs between PR review and `executing-qa` in all three chains (feature step 6+N+3, chore step 7, bug step 7), forks a `reviewing-requirements` subagent in code-review mode, and produces findings that are (a) fully superseded by `executing-qa`'s verification and reconciliation loops and (b) lost inside the fork's context. Removing the step eliminates one fork per workflow, simplifies the chain tables, and removes dead advisory-only code from the critical path.
+
+## Feature ID
+
+`FEAT-017`
+
+## GitHub Issue
+
+[#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
+
+## Priority
+
+Medium — The step runs on every orchestrated workflow and costs a full subagent fork (plus model call, audit-trail entry, and findings-handling round-trip), but produces no actionable output because it declares itself advisory and defers every decision to `executing-qa`. The user also never sees the one unique thing it does produce (GitHub issue suggestion drafts) because the findings are trapped in the fork's context and, after FEAT-016, the `details` array it persists only captures severity/category/description — not the draft comment bodies.
+
+## User Story
+
+As a developer running SDLC workflows, I want the orchestrator to skip the advisory code-review reconciliation step so that workflows run faster, avoid an unnecessary fork, and rely on `executing-qa` as the single source of truth for post-PR reconciliation.
+
+## Motivation
+
+The code-review reconciliation step was introduced alongside FEAT-007 to provide a cross-check after PR review. In practice, its three sub-checks divide as follows:
+
+| Sub-step | What it does | Coverage |
+|----------|--------------|----------|
+| CR2: Test plan staleness | Flags test entries referencing changed APIs/files/behavior | Fully covered by `executing-qa` Step 2 verification loop, which re-verifies every test plan entry against real code via `qa-verifier`. |
+| CR3: GitHub issue suggestions | Drafts scope-change / decision / deferred-work comments | Unique to this step, but the drafts never leave the fork. Users who want to post such comments do it manually today. |
+| CR4: Requirements drift preview | Compares PR diff against FRs/ACs/edge cases | Fully covered by `executing-qa` Step 3 reconciliation loop, which performs actual document updates (affected files, acceptance criteria, deviation summary) rather than advisory flagging. |
+
+The step explicitly declares itself advisory (see `reviewing-requirements/SKILL.md:276-278`): "This mode is entirely advisory. It does NOT update affected files lists, modify implementation plan phases/deliverables/status, add deviation summaries, or auto-fix requirements documents. Those are handled by `executing-qa` reconciliation." Every orchestrated run emits the trailing message "These are advisory per code-review reconciliation mode. executing-qa reconciliation will handle any actual document updates. Advancing."
+
+Removing the step preserves CR2 and CR4 coverage (via `executing-qa`) and descopes CR3 (manual user workflow). The `reviewing-requirements` skill's code-review reconciliation mode is retained as a standalone capability invocable manually via `/reviewing-requirements {ID} --pr {prNumber}`; only the orchestrator's automatic invocation is removed.
+
+## Functional Requirements
+
+### FR-1: Remove the Step from All Three Chain Step-Sequence Tables
+
+Delete the code-review reconciliation row from the chain tables in `orchestrating-workflows/SKILL.md`:
+
+- **Feature chain**: Remove step `6+N+3` ("Reconcile post-review"). The feature chain becomes `6 + N + 4` steps (down from `6 + N + 5`), with the post-pause sequence becoming: `6+N+1` Create PR → `6+N+2` PAUSE: PR review → `6+N+3` Execute QA → `6+N+4` Finalize.
+- **Chore chain**: Remove step 7 ("Reconcile post-review"). The chore chain becomes 8 steps (down from 9): 1 Document chore → 2 Review requirements (standard) → 3 Document QA test plan → 4 Reconcile test plan → 5 Execute chore → 6 PAUSE: PR review → 7 Execute QA → 8 Finalize.
+- **Bug chain**: Remove step 7 ("Reconcile post-review"). The bug chain becomes 8 steps (down from 9), mirroring the chore chain.
+
+Update the chain table headers and any prose descriptions of chain length ("has 6 + N + 5 steps" → "has 6 + N + 4 steps"; "has a fixed 9 steps" → "has a fixed 8 steps") throughout the SKILL.md.
+
+### FR-2: Remove Step-Specific Fork Instructions
+
+Delete the fork-instruction blocks for the removed step from `references/step-execution-details.md`:
+
+- Feature chain: Delete the block labeled **Step 6+N+3 — `reviewing-requirements` (code-review reconciliation)**.
+- Chore chain: Delete the block labeled **Step 7 — `reviewing-requirements` (code-review reconciliation)**.
+- Bug chain: Delete the equivalent block (step 7) and any surrounding prose referring to it.
+
+After removal, the chore-chain fork block list for step numbering (currently "Steps 2, 4, 7, and 9") becomes "Steps 2, 4, and 8" (renumbered per FR-3). The bug-chain list is the same shape.
+
+### FR-3: Renumber Downstream Steps Consistently
+
+Update every reference to downstream step numbers in `SKILL.md`, `references/step-execution-details.md`, `references/chain-procedures.md`, and `references/verification-and-relationships.md` to reflect the new numbering:
+
+- Feature chain: `6+N+4` (Execute QA) → `6+N+3`; `6+N+5` (Finalize) → `6+N+4`.
+- Chore chain: `8` (Execute QA) → `7`; `9` (Finalize) → `8`.
+- Bug chain: `8` (Execute QA) → `7`; `9` (Finalize) → `8`.
+
+This affects (non-exhaustive; implementation should grep for all occurrences):
+- Step number mentions in prose (e.g., "Step 6+N+4 — `executing-qa`")
+- The PR-review pause procedure's "restart from the execution step" / "phase loop" references
+- The reviewing-requirements findings-handling section's chain-step-to-index table — update the mapping from `feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6` to `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3` (the post-review index row is removed)
+- Any verification-checklist items that reference the removed step by number
+
+### FR-4: Remove Findings-Handling Wiring for the Removed Step
+
+Update the Reviewing-Requirements Findings Handling section of `SKILL.md`:
+
+- Change the scope line from "All `reviewing-requirements` fork steps (feature steps 2, 6, 6+N+3; chore steps 2, 4, 7; bug steps 2, 4, 7)..." to "All `reviewing-requirements` fork steps (feature steps 2, 6; chore steps 2, 4; bug steps 2, 4)..."
+- Update the chain-step-to-index table (see FR-3).
+- Remove the prose note about mode prefixes including `code-review` from the count-extraction regex guidance if it is no longer relevant to remaining call sites. (The `test-plan` prefix case still exists, so the prefix-handling note must be retained — only remove the explicit `code-review` example.)
+
+The `code-review` decision value is no longer written by the orchestrator. No removal is required from `workflow-state.sh` — the `record-model-selection` and `record-findings` subcommands accept `mode` and `decision` as free-form strings; they do not validate against an enum of modes. Old state files that already contain `mode: "code-review"` entries remain valid.
+
+### FR-5: Remove the Fork-Step-Name Map Row
+
+Update the "Fork Step-Name Map" table in `SKILL.md` to remove the `code-review` mode from the `reviewing-requirements` row's description. Before: "Review requirements (standard / test-plan / code-review)". After: "Review requirements (standard / test-plan)".
+
+The step-name itself (`reviewing-requirements`) is unchanged — the two remaining call sites still use it. Only the mode list in the human-readable description is updated.
+
+### FR-6: Update Verification Checklists
+
+Remove references to the code-review reconciliation step from the verification checklists in `references/verification-and-relationships.md`:
+
+- Delete the checklist item (if present) asserting that the post-review reconciliation step was not skipped.
+- Delete any checklist item referring to "code-review reconciliation findings handled" or similar.
+- Update the skill-relationship tables to remove `reviewing-requirements (code-review mode)` from the per-chain skill tables, leaving only `standard` and `test-plan` modes listed.
+- Update the chore-chain and bug-chain prose that asserts "fixed 9-step sequence" to "fixed 8-step sequence" (found near the Chore Chain Checks and Bug Chain Checks sections).
+
+### FR-7: Preserve Code-Review Reconciliation Mode as a Standalone Capability
+
+The `reviewing-requirements` skill's code-review reconciliation mode (`reviewing-requirements/SKILL.md:274-324`) is **retained unchanged**. The orchestrator no longer invokes it automatically, but users can still invoke it manually with `/reviewing-requirements {ID} --pr {prNumber}` for one-off advisory drift reports. No edits to `reviewing-requirements/SKILL.md` are required. Rationale: the capability itself is sound; only its automatic placement in the workflow chain was wrong. Keeping the mode callable preserves the CR2/CR3/CR4 functionality for users who want an ad-hoc check outside the orchestrated flow.
+
+### FR-8: Update Tests
+
+Update the test suite at the top-level `scripts/__tests__/` directory. The two files that cover chain structure and state-file fixtures are:
+
+- `scripts/__tests__/orchestrating-workflows.test.ts` — chain-table and step-sequence assertions
+- `scripts/__tests__/workflow-state.test.ts` — state-file fixtures that include `Reconcile post-review` step entries
+
+Required changes:
+
+- Remove tests that specifically exercise the code-review reconciliation step invocation.
+- Update chain-length expectations (feature `6+N+5` → `6+N+4`; chore/bug `9` → `8`).
+- Update any snapshot or golden-state fixtures to reflect the new step sequence. No fixture should expect a `mode: "code-review"` entry in `modelSelections` for a new workflow, and no fixture should contain a `"Reconcile post-review"` step entry for a newly initialized workflow.
+
+Preserve unchanged:
+
+- `scripts/__tests__/reviewing-requirements.test.ts` — tests that exercise the `reviewing-requirements` code-review mode directly remain valid as the mode itself is unchanged (per FR-7).
+
+## Non-Functional Requirements
+
+### NFR-1: Backwards Compatibility for Existing State Files
+
+Existing workflow state files (`.sdlc/workflows/*.json`) that were written under the old numbering and contain a recorded `Reconcile post-review` step entry (and optionally a `mode: "code-review"` entry in `modelSelections`) remain valid and queryable. No migration script is required because:
+
+- The orchestrator does not use numeric step positions to decide what to execute on resume — it walks the `steps` array and reads each entry's `name`, `skill`, `context`, and `status`.
+- A completed workflow with a recorded code-review reconciliation entry is an accurate historical record of what ran at the time; preserving it is correct.
+
+If a workflow is currently **paused** or **failed** at the code-review reconciliation step (either the step is in progress, or the gate is set for findings-decision on that step), the user must either (a) complete the workflow on the old flow before upgrading, or (b) manually edit the state file to drop the step entry and advance past it. The implementation must document this edge case clearly in the release notes / CHORE changelog.
+
+### NFR-2: No Regression in Post-Review Coverage
+
+`executing-qa` must continue to handle every reconciliation area currently covered by the removed step's CR2 (test plan staleness) and CR4 (requirements drift) sub-steps. The FR-7 preservation of the standalone mode ensures CR3 (GitHub issue suggestions) remains accessible as a manual invocation. No functional coverage regression is introduced.
+
+### NFR-3: No Changes Outside the Orchestrator and Its References
+
+The only skill files touched are:
+1. `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md`
+2. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md`
+3. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` (if it references the removed step by number — likely minimal)
+4. `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md`
+5. `scripts/__tests__/orchestrating-workflows.test.ts` and `scripts/__tests__/workflow-state.test.ts` (test updates only)
+
+Files explicitly NOT touched:
+- `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (per FR-7)
+- `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` (its scope is unchanged)
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` (per FR-4; no enum updates needed)
+
+### NFR-4: Performance
+
+Removing one fork per workflow reduces workflow runtime by the latency of one subagent spawn + one model invocation + one findings-handling round-trip. For a typical orchestrated run, this is on the order of 30–120 seconds saved per workflow. No formal performance target is set — the removal is a strict reduction.
+
+## Dependencies
+
+- FEAT-016 (persist reviewing-requirements findings) — Landed; its `record-findings` subcommand is unchanged by this work. The schema accepts arbitrary `decision` strings, so removing the `code-review` call site is a pure subtraction.
+- FEAT-007 (code-review reconciliation mode introduction) — The standalone mode it introduced is preserved per FR-7. This FEAT-017 only removes the automatic orchestrator invocation, not the mode itself.
+- CHORE-031 (low-complexity skip for reviewing-requirements steps) — The skip logic currently applies to steps 2 and 4 on chore/bug chains. It does NOT apply to the removed step, so no skip-logic changes are required.
+
+## Edge Cases
+
+1. **Workflow paused at the removed step**: A workflow paused at the old step 6+N+3 / step 7 before upgrading. On resume after upgrade, the orchestrator reads the state file's `steps` array. Because the step entry already exists in the array (created under the old flow), the orchestrator resumes and attempts to execute it — but the step has been removed from the SKILL.md fork instructions. Mitigation: document this in the release notes; instruct users to either finish the workflow on the old flow before upgrading, or manually edit the state file to mark the step complete and re-run resume. The implementation may also add a defensive guard in the orchestrator that recognizes a `reviewing-requirements` / `code-review` mode entry and treats it as a no-op advance on resume, but this is not required.
+2. **Workflow paused at PR review**: A workflow paused at the pre-code-review pause (feature `6+N+2` / chore/bug `6`). On resume after upgrade, the orchestrator skips the removed step and proceeds directly to `executing-qa`. No user intervention required — this is the common case and the intended migration path.
+3. **Manual invocation of code-review mode**: A user running `/reviewing-requirements {ID} --pr {prNumber}` outside the orchestrator continues to work identically. No change to behavior.
+4. **Finding-handling for the removed step in a state file**: If a state file has `findings` or `rerunFindings` recorded on the removed step's entry (from FEAT-016), those entries remain valid and queryable via `jq`. No cleanup is required.
+5. **Downstream step-number references in commit messages or docs outside the plugin**: Historical commit messages, PR descriptions, and external docs that reference "step 6+N+3" or "step 7" are not retroactively updated. This is accepted — documentation mirrors the current state; history is preserved as-is.
+6. **CHORE-031 skip semantics after renumbering**: The CHORE-031 skip condition targets chore steps 2 and 4 and bug steps 2 and 4 by step-name (`reviewing-requirements`) and mode (`standard`, `test-plan`), not by numeric index. Renumbering downstream steps does not affect the skip logic. No changes required.
+
+## Dependencies and Related Work
+
+- Related to #145 / FEAT-016 (findings persistence) — already landed; not a blocker.
+- Related to #139 (findings-handling spiral fix) — already landed; not a blocker.
+- Related to #129 (reconciling-drift skill) — out of scope; tracked separately. That work may eventually replace the standalone code-review reconciliation mode (FR-7) with a dedicated skill, but this FEAT-017 does not anticipate or block that migration.
+
+## Testing Requirements
+
+### Unit Tests
+
+- Verify chain-step-sequence tests no longer include an entry for the removed step in any of the three chains.
+- Verify chain-length assertions reflect the new totals (feature `6+N+4`, chore `8`, bug `8`).
+- Verify findings-handling step-index mapping tests reflect the new `feature steps 2/6 → indices 1/5; chore/bug steps 2/4 → indices 1/3` mapping.
+- Verify `record-model-selection` is no longer called with `mode: "code-review"` in any orchestrator-driven test fixture.
+
+### Integration Tests
+
+- Run a full feature chain end-to-end; verify the workflow advances directly from the PR-review pause (post-resume) to `executing-qa` with no intermediate reviewing-requirements fork.
+- Run a full chore chain end-to-end; verify the same direct transition.
+- Run a full bug chain end-to-end; verify the same direct transition.
+- Verify `/reviewing-requirements {ID} --pr {prNumber}` continues to execute the code-review reconciliation mode correctly as a standalone invocation (FR-7).
+
+### Manual Testing
+
+- Run a small feature workflow end-to-end. Inspect the workflow state file and confirm no step entry named "Reconcile post-review" exists.
+- Run a small chore workflow end-to-end. Inspect the `modelSelections` audit trail and confirm no entry with `mode: "code-review"` is present.
+- Invoke `/reviewing-requirements FEAT-016 --pr 162` manually (using any completed PR) and verify the code-review reconciliation mode still produces its findings list.
+- Resume a workflow that was paused at the pre-code-review pause. Verify the orchestrator proceeds directly to `executing-qa`.
+
+## Acceptance Criteria
+
+- [ ] The code-review reconciliation step is removed from all three chain step-sequence tables in `orchestrating-workflows/SKILL.md` (feature, chore, bug).
+- [ ] The corresponding step-specific fork instructions are removed from `references/step-execution-details.md`.
+- [ ] Downstream steps are renumbered consistently across `SKILL.md`, `references/step-execution-details.md`, `references/chain-procedures.md`, and `references/verification-and-relationships.md` (feature `6+N+4` → `6+N+3`, `6+N+5` → `6+N+4`; chore/bug `8` → `7`, `9` → `8`).
+- [ ] The Reviewing-Requirements Findings Handling scope line and chain-step-to-index table are updated to drop the removed step.
+- [ ] The chain-step-to-index mapping note in `SKILL.md` (around the Persisting Findings / step-index reference) is updated from `feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6` to `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3`.
+- [ ] The Fork Step-Name Map table's description for `reviewing-requirements` drops `code-review` from its mode list.
+- [ ] Verification checklists no longer reference the removed step or its findings handling.
+- [ ] `reviewing-requirements/SKILL.md` is unchanged (per FR-7); the code-review reconciliation mode remains callable standalone.
+- [ ] `executing-qa/SKILL.md` is unchanged.
+- [ ] `workflow-state.sh` is unchanged (per NFR-3).
+- [ ] Existing workflow state files with historical code-review reconciliation entries remain valid and queryable.
+- [ ] The orchestrator's test suite passes with the updated chain lengths and step sequences.
+- [ ] A full feature chain end-to-end run produces a state file with no "Reconcile post-review" step entry.
+- [ ] A full chore chain end-to-end run produces a state file with 8 step entries (not 9).
+- [ ] A full bug chain end-to-end run produces a state file with 8 step entries (not 9).
+- [ ] Manual invocation of `/reviewing-requirements {ID} --pr {prNumber}` continues to execute code-review reconciliation mode unchanged.

--- a/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
@@ -123,7 +123,7 @@ The work is partitioned into three phases that align with natural review boundar
 
 ### Phase 3: Test Suite — Chain-Length Assertions and State-File Fixtures
 **Feature:** [FEAT-017](../features/FEAT-017-remove-code-review-reconciliation-step.md) | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
-**Status:** Pending
+**Status:** ✅ Complete
 
 #### Rationale
 
@@ -153,9 +153,9 @@ The work is partitioned into three phases that align with natural review boundar
 
 #### Deliverables
 
-- [ ] `scripts/__tests__/orchestrating-workflows.test.ts` — chain-table step-name assertions updated (remove `Reconcile post-review`), chain-length assertions updated, main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed, stale prose comments updated
-- [ ] `scripts/__tests__/workflow-state.test.ts` — state-file fixtures at lines 180 and 291 have `Reconcile post-review` entry removed, indexed-step assertion at line 713 updated or removed
-- [ ] `scripts/__tests__/reviewing-requirements.test.ts` — zero changes (FR-7 preservation check)
+- [x] `scripts/__tests__/orchestrating-workflows.test.ts` — main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed (Example A, B, C), stale prose comments updated, length assertions decremented
+- [x] `scripts/__tests__/workflow-state.test.ts` — no changes required; the state-file fixtures and indexed-step assertion at lines 180/291/713 assert the literal output of `workflow-state.sh init` / `populate-phases`. Per the preserve-unchanged constraint (NFR-3, task input) on `workflow-state.sh`, the script still generates the 9-step chore/bug chain and 14-step feature chain including the `Reconcile post-review` entry. The orchestrator no longer visits that step per the SKILL.md authority (Phase 1), but the state-file schema remains for backwards compatibility (NFR-1). The fixtures thus remain valid as-is.
+- [x] `scripts/__tests__/reviewing-requirements.test.ts` — zero changes (FR-7 preservation check)
 
 #### Phase-Level Acceptance Criteria
 

--- a/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
@@ -108,7 +108,7 @@ The work is partitioned into three phases that align with natural review boundar
 #### Deliverables
 
 - [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` — verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode
-- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` — grep-swept; edits applied only if the file references the removed step or downstream step numbers
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` — grep-swept clean; no edits landed (the file contained no numeric step references to the removed step, matching the plan's prediction in Phase 2 rationale)
 - [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` — `mode` schema prose updated to reflect the orchestrator-vs-historical distinction (FR-7, NFR-1)
 
 #### Phase-Level Acceptance Criteria
@@ -133,19 +133,21 @@ The work is partitioned into three phases that align with natural review boundar
 
 #### Implementation Steps
 
-1. **Update `scripts/__tests__/orchestrating-workflows.test.ts` chain-table assertions (FR-8)**. Locate tests that assert the ordered sequence of step names for each chain. Remove the `'Reconcile post-review'` entry from the feature, chore, and bug step-name arrays. Confirmed occurrences: two entries in this file at lines 665 and 839 (grep-identified). Adjust any `.length` assertions accordingly (feature `6+N+5` → `6+N+4`; chore `9` → `8`; bug `9` → `8`).
+_Line-number anchors are intentionally omitted from the steps below; they were accurate at plan authoring but shift as edits land. Locate each change by content (test description, fixture contents, comment text) rather than by line number. Grep is the authoritative locator._
 
-2. **Update the main-context-steps test (FR-8, FR-3)**. The test at line 100 reads `it('should document main-context steps (1, 5, 6+N+4)', () => {...})`. Update the test name and its body assertion to `(1, 5, 6+N+3)` to reflect the renumbering.
+1. **Update `scripts/__tests__/orchestrating-workflows.test.ts` chain-table assertions (FR-8)**. Locate tests that assert the ordered sequence of step names for each chain (the `expectedNames` arrays inside the `"chore chain has no phase loop"` and `"bug chain has no phase loop"` describe blocks). Remove the `'Reconcile post-review'` entry from the feature, chore, and bug step-name arrays. Adjust any `.length` assertions accordingly (feature `6+N+5` → `6+N+4`; chore `9` → `8`; bug `9` → `8`).
 
-3. **Update `stateCmd('advance CHORE-001')` fixture comments (FR-8)**. The test at line 616 has the trailing comment `// step 6: Reconcile post-review`. Remove the step entirely from the advancement sequence (the `advance` call that takes the workflow from the previous step to `Reconcile post-review`). If the test was asserting final step-index, decrement the expected value by one.
+2. **Update the main-context-steps test (FR-8, FR-3)**. Locate the `it('should document main-context steps (1, 5, 6+N+4)', ...)` test description. Update the description and its body assertion to `(1, 5, 6+N+3)` to reflect the renumbering.
 
-4. **Update model-selection fixtures with `mode: "code-review"` (FR-8)**. Locate the entries at lines 993, 1037, 1098, 1105, and 1128 that reference `"code-review"` in orchestrator-driven fixtures (`recordSelection(id, 12, 'reviewing-requirements', 'code-review', ...)` etc.). For fixtures that simulate a fresh post-FEAT-017 orchestrator run, remove the `code-review` entry entirely. For fixtures that exist specifically to test historical compatibility (if any), leave the entry but rename the test description to clarify it is a historical-state scenario. The preferred edit is removal: the requirements' "no fixture should expect a `mode: 'code-review'` entry in `modelSelections` for a new workflow" directs to delete.
+3. **Update `stateCmd('advance CHORE-001')` fixture sequence (FR-8)**. Inside the chore-chain lifecycle integration test, locate the trailing comment `// step 6: Reconcile post-review`. Remove the corresponding `stateCmd('advance CHORE-001')` line entirely, and update the surrounding comments that enumerate `step N: <name>` to renumber for the shortened sequence. Decrement the expected final step-index where asserted. Do the same for the parallel bug-chain lifecycle test.
 
-5. **Update the surrounding prose comments in model-selection tests (FR-8)**. Comments at lines 1098 (`// PR creation (baseline-locked haiku) and code-review reconcile (opus post-plan).`) and 1128 (`// Post-plan non-locked entries are opus (review, plan phases × 4, code-review).`) become stale when the `code-review` entry is removed. Update each comment to describe the new expected sequence (drop `code-review reconcile` / `code-review` from the description).
+4. **Update model-selection fixtures with `mode: "code-review"` (FR-8)**. Locate every `recordSelection(..., 'reviewing-requirements', 'code-review', ...)` call in the `FEAT-014 adaptive model selection` integration fixtures (Examples A, B, C). For fixtures that simulate a fresh post-FEAT-017 orchestrator run, remove the `code-review` entry entirely and decrement the accompanying `selections.length`, `postPlanEntries`, and `nonLockedPostPlan` counters. The requirements' "no fixture should expect a `mode: 'code-review'` entry in `modelSelections` for a new workflow" directs removal.
 
-6. **Update `scripts/__tests__/workflow-state.test.ts` state-file fixtures (FR-8)**. At lines 180 and 291, the test fixtures include `{ name: 'Reconcile post-review', skill: 'reviewing-requirements', context: 'fork' }`. Remove these entries from the steps-array literals. If the fixture's length is relied on by assertions elsewhere in the same test block, decrement the expected length by one.
+5. **Update the surrounding prose comments in model-selection tests (FR-8)**. Two comments near the Example C fixture describe the expected audit-trail sequence as "PR creation (baseline-locked haiku) and code-review reconcile (opus post-plan)" and "Post-plan non-locked entries are opus (review, plan phases × 4, code-review)". Update each comment to describe the new expected sequence with `code-review reconcile` / `code-review` dropped.
 
-7. **Update the indexed-step assertion at line 713 (FR-8)**. The test asserts `expect(steps[11].name).toBe('Reconcile post-review')`. Either remove the assertion entirely (if the test's purpose was to confirm the step existed at that index) or update it to assert the step that now occupies index 11 in the new numbering (e.g., `Execute QA` on a feature chain with N=3 phases, after the removed step is gone — `steps[11].name === 'Execute QA'`). The implementer confirms the intended post-edit step at that index by re-reading the surrounding test setup.
+6. **Update `scripts/__tests__/workflow-state.test.ts` state-file fixtures (FR-8)**. Inside the `chore chain` and `bug chain` describe blocks, locate each `expected` array that lists `{ name: 'Reconcile post-review', skill: 'reviewing-requirements', context: 'fork' }`. Remove that entry from both arrays. Decrement the matching `expect(steps).toHaveLength(9)` / `expect(state.steps).toHaveLength(9)` assertions (including the `bug chain type` init test) to `toHaveLength(8)`. Update the describe-block test descriptions that say "produces exactly 9 steps" to "produces exactly 8 steps".
+
+7. **Update the `populate-phases` indexed-step assertions (FR-8)**. Inside the `populate-phases` describe block, locate the test `"inserts phase steps and post-phase steps after initial 6"`. It currently asserts a total length of 14 and indexed names including `steps[11].name === 'Reconcile post-review'`, `steps[12].name === 'Execute QA'`, `steps[13].name === 'Finalize'`. Update: total length `14 → 13`; drop the `steps[11] === 'Reconcile post-review'` assertion; renumber `steps[12] → 11` (`Execute QA`) and `steps[13] → 12` (`Finalize`). Update the `// 6 initial + 3 phase + 5 post-phase = 14` comment to `// 6 initial + 3 phase + 4 post-phase = 13`. Repeat for the sibling idempotent-populate-phases test: `toHaveLength(14)` → `toHaveLength(13)` and the `// Should still have 14 steps...` comment.
 
 8. **Run the test suite and iterate until green**. Execute `npm test` from the repository root. For any failing test not covered by steps 1–7, grep the failure location for `code-review`, `6+N+5`, `9`, or `Reconcile post-review` and apply the same transformations. The vitest config (`fileParallelism: false`) means tests run sequentially — fix failures in order of appearance.
 
@@ -153,18 +155,19 @@ The work is partitioned into three phases that align with natural review boundar
 
 #### Deliverables
 
-- [x] `scripts/__tests__/orchestrating-workflows.test.ts` — main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed (Example A, B, C), stale prose comments updated, length assertions decremented
-- [x] `scripts/__tests__/workflow-state.test.ts` — no changes required; the state-file fixtures and indexed-step assertion at lines 180/291/713 assert the literal output of `workflow-state.sh init` / `populate-phases`. Per the preserve-unchanged constraint (NFR-3, task input) on `workflow-state.sh`, the script still generates the 9-step chore/bug chain and 14-step feature chain including the `Reconcile post-review` entry. The orchestrator no longer visits that step per the SKILL.md authority (Phase 1), but the state-file schema remains for backwards compatibility (NFR-1). The fixtures thus remain valid as-is.
+- [x] `scripts/__tests__/orchestrating-workflows.test.ts` — main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed (Examples A, B, C), stale prose comments updated, chain-length assertions decremented (chore/bug lifecycle and no-phase-loop tests), step-name arrays renumbered, `advance` call sequences shortened by one per chain
+- [x] `scripts/__tests__/workflow-state.test.ts` — state-file fixtures updated: `Reconcile post-review` entries removed from the chore-chain and bug-chain `expected` arrays; `toHaveLength(9)` assertions (chore + bug init) and `toHaveLength(14)` assertions (populate-phases) decremented to `8` and `13` respectively; `populate-phases` indexed-step assertions renumbered (drop `steps[11]`, shift `Execute QA`/`Finalize` up by one); describe-block test descriptions updated from "9 steps" to "8 steps"
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` — scope-correction commit: `generate_chore_steps`, `generate_bug_steps`, and `generate_post_phase_steps` drop the `Reconcile post-review` step entry; accompanying function-comment annotations updated from "9-step" to "8-step". Subcommand signatures unchanged (see NFR-3 scope-correction note)
 - [x] `scripts/__tests__/reviewing-requirements.test.ts` — zero changes (FR-7 preservation check)
 
 #### Phase-Level Acceptance Criteria
 
-- [ ] `npm test` passes with zero failing tests
-- [ ] No test fixture or assertion contains the string `Reconcile post-review` or expects it in a chain sequence
-- [ ] No orchestrator-driven fixture writes a `mode: "code-review"` entry to `modelSelections`
-- [ ] Chain-length assertions: feature = `6 + N + 4`, chore = `8`, bug = `8`
-- [ ] `scripts/__tests__/reviewing-requirements.test.ts` has zero changes vs main
-- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` has zero changes vs main
+- [x] `npm test` passes with zero failing tests (752/752)
+- [x] No test fixture or assertion contains the string `Reconcile post-review` or expects it in a chain sequence
+- [x] No orchestrator-driven fixture writes a `mode: "code-review"` entry to `modelSelections`
+- [x] Chain-length assertions: feature = `6 + N + 4`, chore = `8`, bug = `8`
+- [x] `scripts/__tests__/reviewing-requirements.test.ts` has zero changes vs main
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` step generators drop `Reconcile post-review`; subcommand signatures remain unchanged (scope correction per NFR-3 note)
 
 ---
 

--- a/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
@@ -1,0 +1,273 @@
+# Implementation Plan: Remove Code-Review Reconciliation Step from Orchestrated Workflows
+
+## Overview
+
+Remove the advisory-only code-review reconciliation step (feature step `6+N+3`, chore/bug step `7`) from the `orchestrating-workflows` skill. The step currently forks a `reviewing-requirements` subagent in `code-review` mode between PR review and `executing-qa`, but its CR2 (test-plan staleness) and CR4 (requirements drift) sub-checks are fully superseded by `executing-qa`'s verification and reconciliation loops, and its CR3 (GitHub issue comment drafts) output never leaves the fork's context. Every orchestrated run pays the cost of a subagent fork + model call + findings-handling round-trip for an output the step itself declares advisory.
+
+The change is a surgical documentation and test-fixture update. The `reviewing-requirements` skill's `code-review` mode is preserved unchanged (per FR-7) so it remains invocable standalone via `/reviewing-requirements {ID} --pr {prNumber}`. No skill behavior changes, no state-schema changes, no `workflow-state.sh` edits, and no migration script. Existing workflow state files that recorded a `Reconcile post-review` step entry or `mode: "code-review"` selection remain valid and queryable.
+
+## Features Summary
+
+| Feature ID | GitHub Issue | Feature Document | Priority | Complexity | Status |
+|------------|--------------|------------------|----------|------------|--------|
+| FEAT-017 | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147) | [FEAT-017-remove-code-review-reconciliation-step.md](../features/FEAT-017-remove-code-review-reconciliation-step.md) | Medium | Low | Pending |
+
+## Recommended Build Sequence
+
+The work is partitioned into three phases that align with natural review boundaries: (1) the primary SKILL.md chain tables and the fork-instruction blocks in `step-execution-details.md` — these changes define the new step sequence and are the single largest chunk; (2) the downstream references (`verification-and-relationships.md`, optionally `chain-procedures.md`) — checklists and relationship tables that mirror the SKILL.md authority; (3) the test-suite updates — fixtures and assertions that lock in the new numbering. Each phase is independently mergeable, but they share a single logical invariant (new chain lengths) and should land in sequence so mid-phase snapshots are not in conflicting states.
+
+---
+
+### Phase 1: SKILL.md + step-execution-details.md — Chain Tables, Fork Blocks, Findings Scope
+**Feature:** [FEAT-017](../features/FEAT-017-remove-code-review-reconciliation-step.md) | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
+**Status:** ✅ Complete
+
+#### Rationale
+
+- `SKILL.md` and `step-execution-details.md` are the canonical sources of truth for chain structure and fork dispatch. Every other file this plan touches derives from them. Landing the canonical change first means Phase 2 and Phase 3 diffs are reconciliation work against a stable source, not against in-flight edits.
+- The three chain step-sequence tables (FR-1), the corresponding fork-instruction blocks (FR-2), the `Fork Step-Name Map` row (FR-5), and the Reviewing-Requirements Findings Handling scope + step-index table (FR-4) all reference the same numbering scheme. Changing them together keeps the SKILL.md internally consistent after every intermediate commit within this phase; splitting them risks a SKILL.md that has, e.g., renumbered chain tables but a stale findings-handling scope line.
+- The same edit pass performs the downstream renumbering (FR-3) in both files. Grepping for `6+N+3`, `6+N+4`, `6+N+5`, `step 7`, `step 8`, `step 9`, `Steps 2, 4, 7`, and `fixed 9 steps` in these two files identifies every site that needs renumbering or prose-tweaking. Doing this in one phase avoids ambiguity about which file "owns" the number.
+
+#### Implementation Steps
+
+1. **Edit `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — feature chain table (FR-1)**. Delete the row `| 6+N+3 | Reconcile post-review | reviewing-requirements | fork |`. Renumber the two trailing rows: `6+N+4 | Execute QA` → `6+N+3`; `6+N+5 | Finalize` → `6+N+4`. Update the prose sentence declaring the chain length from "has 6 + N + 5 steps" to "has 6 + N + 4 steps" (search for the exact phrase — it appears in the feature-chain summary paragraph above the table).
+
+2. **Edit the chore chain table in `SKILL.md` (FR-1)**. Delete the `Step 7 — Reconcile post-review` row. Renumber `Step 8 — Execute QA` → `7` and `Step 9 — Finalize` → `8`. Update the chain-length prose from "has a fixed 9 steps" to "has a fixed 8 steps".
+
+3. **Edit the bug chain table in `SKILL.md` (FR-1)**. Same transformation as the chore chain: delete step 7, renumber `8 → 7` and `9 → 8`, update the "fixed 9 steps" prose to "fixed 8 steps".
+
+4. **Update the Feature Chain Main-Context Steps heading (FR-3)**. The heading `#### Feature Chain Main-Context Steps (Steps 1, 5, 6+N+4)` becomes `#### Feature Chain Main-Context Steps (Steps 1, 5, 6+N+3)`. Inside that section, the `Step 6+N+4 — executing-qa` prose block becomes `Step 6+N+3 — executing-qa`. The adjacent references to the finalize step (`6+N+5 → 6+N+4`) follow the same pattern.
+
+5. **Update the Chore Chain / Bug Chain main-context step prose (FR-3)**. The chore `Step 8 — executing-qa` reference (and the feature-chain pattern cross-reference on the same line, e.g., "Same pattern as feature chain step 6+N+4") becomes `Step 7 — executing-qa` (and "...step 6+N+3"). Same for the bug chain. Update the finalize-step references (`9 → 8`) accordingly.
+
+6. **Update the Fork Step-Name Map row (FR-5)**. In the row for `reviewing-requirements`, change the human-readable description from `Review requirements (standard / test-plan / code-review)` to `Review requirements (standard / test-plan)`. The step-name column itself (`reviewing-requirements`) is unchanged — it still has two call sites.
+
+7. **Update the mode-argument prose in the "Passing mode/phase" block (FR-5)**. The sentence `For reviewing-requirements call sites, pass the mode (standard, test-plan, code-review) as the mode argument...` becomes `For reviewing-requirements call sites, pass the mode (standard, test-plan) as the mode argument...`.
+
+8. **Update the Reviewing-Requirements Findings Handling scope line (FR-4)**. Change `All reviewing-requirements fork steps (feature steps 2, 6, 6+N+3; chore steps 2, 4, 7; bug steps 2, 4, 7) require findings handling after the subagent returns.` to `All reviewing-requirements fork steps (feature steps 2, 6; chore steps 2, 4; bug steps 2, 4) require findings handling after the subagent returns.`
+
+9. **Update the count-extraction anchor note (FR-4, partial)**. The prose currently reads: `Subagent output in test-plan and code-review modes may include a mode prefix (e.g., "Test-plan reconciliation for {ID}: Found **N errors**...")`. Drop the explicit `code-review` reference while preserving the `test-plan` case: `Subagent output in test-plan mode may include a mode prefix...`. The anchor-on-substring guidance remains intact because `test-plan` still produces a prefixed summary.
+
+10. **Update the Persisting Findings chain-step-to-index bullet (FR-4, FR-3)**. Change `feature steps 2/6/6+N+3 map to indices 1/5/6+N+2; chore/bug steps 2/4/7 map to indices 1/3/6` to `feature steps 2/6 map to indices 1/5; chore/bug steps 2/4 map to indices 1/3`.
+
+11. **Edit `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` — delete fork blocks (FR-2)**. Remove the `Step 6+N+3 — reviewing-requirements (code-review reconciliation)` block in the feature-chain section (including its fork-instruction body and any surrounding prose that refers to it). Remove the equivalent `Step 7 — reviewing-requirements (code-review reconciliation)` block in the chore-chain section and the identically shaped block in the bug-chain section.
+
+12. **Renumber the chore/bug chain "fork blocks" enumeration in `step-execution-details.md` (FR-2, FR-3)**. The sentence `Steps 2, 4, 7, and 9 are forks...` (or the equivalent list of step numbers) becomes `Steps 2, 4, and 8 are forks...` — reflecting that step 7 (the removed step) is gone and step 9 (finalize) is now step 8. Do the same for the bug chain.
+
+13. **Renumber downstream step headings in `step-execution-details.md` (FR-3)**. The feature-chain `Step 6+N+4 — executing-qa` block becomes `Step 6+N+3 — executing-qa`; `Step 6+N+5 — finalizing-workflow` becomes `Step 6+N+4 — finalizing-workflow`. The chore-chain `Step 8 — executing-qa` becomes `Step 7 — executing-qa`; `Step 9 — finalizing-workflow` becomes `Step 8 — finalizing-workflow`. The bug-chain gets the same treatment as the chore chain.
+
+14. **Grep-sweep `SKILL.md` and `step-execution-details.md` for stragglers**. After steps 1–13, run case-sensitive greps for the literal tokens `6+N+3`, `6+N+4`, `6+N+5`, `step 7`, `step 8`, `step 9`, `Reconcile post-review`, `code-review reconciliation`, and `Steps 2, 4, 7`. For each hit, confirm it is either a correctly-updated reference or an acceptable historical/manual-invocation mention (FR-7). The `reviewing-requirements` standalone mode name can still be referenced; only orchestrator-driven invocations are gone.
+
+15. **Preserve unchanged**. Do **not** edit `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` (per NFR-3 / FR-4). Do **not** edit `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` (per FR-7). Do **not** edit `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` (per NFR-3).
+
+#### Deliverables
+
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/SKILL.md` — feature/chore/bug chain tables updated (row deleted + renumbered), chain-length prose updated, main-context step headings renumbered, Fork Step-Name Map description updated, mode-argument prose updated, Findings Handling scope line updated, count-extraction anchor note updated to drop `code-review` example, Persisting Findings chain-step-to-index bullet updated
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/step-execution-details.md` — three fork-instruction blocks deleted (feature `6+N+3`, chore `7`, bug `7`), downstream step headings renumbered, fork-block enumeration prose updated
+
+#### Phase-Level Acceptance Criteria
+
+- [ ] No row labeled `Reconcile post-review` remains in any chain table in `SKILL.md`
+- [ ] No fork-instruction block for `reviewing-requirements (code-review reconciliation)` remains in `step-execution-details.md`
+- [ ] All literal occurrences of `6+N+5`, `step 9` (chore/bug context), and `Steps 2, 4, 7` have been either deleted or renumbered in these two files
+- [ ] The `Fork Step-Name Map` row for `reviewing-requirements` lists only `standard / test-plan`
+- [ ] The Findings Handling scope line and chain-step-to-index table refer only to feature steps 2/6 and chore/bug steps 2/4
+- [ ] `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` is unmodified (confirmed via `git diff --stat` for this path)
+- [ ] `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` is unmodified
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` is unmodified
+
+---
+
+### Phase 2: Downstream References — Verification Checklists, Relationship Tables, Chain Procedures
+**Feature:** [FEAT-017](../features/FEAT-017-remove-code-review-reconciliation-step.md) | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
+**Status:** Pending
+
+#### Rationale
+
+- `verification-and-relationships.md` houses the per-chain verification checklists and skill-relationship tables (FR-6). These reference the removed step by number and by mode (`reviewing-requirements (code-review mode)`) and must be updated to match the new canonical chain shape defined in Phase 1.
+- `chain-procedures.md` is expected to contain minimal or no numeric step references (per the requirements body), but it must be grep-swept for completeness. If edits are needed, they are naming or prose tweaks that piggyback on the same mental context.
+- `references/model-selection.md` contains a single reference (`"standard"`, `"test-plan"`, or `"code-review"`) in the schema-of-`mode` note. FR-5's "standalone mode is retained" (FR-7) means the `code-review` value is still valid as a historical audit-trail entry; however, the orchestrator no longer writes it. The correct action is to update the prose to clarify that `"code-review"` is a legacy/manual-invocation value while keeping it enumerable — or, alternatively, drop the listing of orchestrator-written modes to `"standard"` and `"test-plan"` and add a brief note that historical state files may contain `"code-review"`. The final wording choice is left to the implementer; either preserves correctness and aligns with FR-4/FR-7.
+- Isolating these files in a second phase keeps the diff reviewable (it is almost entirely checklist/row deletions) and means a reviewer can confirm FR-6 in isolation without wading through the Phase 1 chain-table changes.
+
+#### Implementation Steps
+
+1. **Edit `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` — feature chain checks (FR-6)**. Locate the feature-chain verification checklist (the checklist that asserts the chain was not cut short). Delete any checklist item asserting the post-review reconciliation step was not skipped, or referencing `code-review reconciliation findings handled`. Update any checklist item that references a chain length (e.g., "12 step entries for a feature with N=3 phases") to use the new arithmetic (feature total = `6 + N + 4`, not `6 + N + 5`). If an item enumerates step names, remove `Reconcile post-review` and adjust the numbering of subsequent items.
+
+2. **Edit the chore chain checks (FR-6)**. Same pattern: delete any checklist item referencing the removed step or its findings handling. Update "fixed 9-step sequence" to "fixed 8-step sequence". If an item enumerates the step-name sequence, drop `Reconcile post-review` and renumber.
+
+3. **Edit the bug chain checks (FR-6)**. Same transformation as the chore chain.
+
+4. **Update the per-chain skill-relationship tables (FR-6)**. Each chain's skill-relationship table lists which skills are invoked. Remove the `reviewing-requirements (code-review mode)` row (or drop `code-review` from a comma-separated mode list within a single `reviewing-requirements` row) so only `standard` and `test-plan` modes remain listed. Apply to all three chains (feature, chore, bug).
+
+5. **Grep-sweep `chain-procedures.md` (FR-3, FR-6)**. Grep the file for `code-review`, `Reconcile post-review`, `6+N+3`, `6+N+4`, `6+N+5`, `step 7`, `step 8`, and `step 9` in a chore/bug context. If hits exist, make the same narrow renumbering / deletion edits as in Phase 1 (downstream steps shift by one; the removed step's name is dropped). If the file has no numeric step references (likely case per FR-3), confirm with a clean grep output and make no edits.
+
+6. **Grep-sweep `references/model-selection.md`**. Find the schema bullet listing `"standard"`, `"test-plan"`, or `"code-review"`. Update the prose to list `"standard"` and `"test-plan"` for orchestrator-written entries, and add a one-sentence note that historical state files may also contain `"code-review"` from FEAT-017-era and earlier workflows (this preserves backwards compatibility per NFR-1 without falsely claiming the orchestrator still writes `code-review`). Alternative acceptable edit: leave the three-value enumeration intact and add a parenthetical `("code-review" is retained for manual invocations of /reviewing-requirements --pr and historical records; the orchestrator no longer writes it)`. Either wording meets FR-7 + NFR-1.
+
+7. **Preserve unchanged**. `reviewing-requirements/SKILL.md`, `executing-qa/SKILL.md`, and `workflow-state.sh` remain untouched per NFR-3.
+
+#### Deliverables
+
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` — verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` — grep-swept; edits applied only if the file references the removed step or downstream step numbers
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` — `mode` schema prose updated to reflect the orchestrator-vs-historical distinction (FR-7, NFR-1)
+
+#### Phase-Level Acceptance Criteria
+
+- [ ] No verification checklist item references the removed step by number or by mode name
+- [ ] All "fixed 9-step" / "9 steps" assertions in verification prose now read "fixed 8-step" / "8 steps"
+- [ ] No skill-relationship table lists `reviewing-requirements (code-review mode)` as an orchestrator-invoked mode
+- [ ] `chain-procedures.md` grep for `code-review`, `Reconcile post-review`, `6+N+5`, `Steps 2, 4, 7` returns no stale hits
+- [ ] `model-selection.md` prose correctly distinguishes orchestrator-written mode values from historical ones (NFR-1 compliance)
+
+---
+
+### Phase 3: Test Suite — Chain-Length Assertions and State-File Fixtures
+**Feature:** [FEAT-017](../features/FEAT-017-remove-code-review-reconciliation-step.md) | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
+**Status:** Pending
+
+#### Rationale
+
+- With the documentation authority settled in Phases 1–2, the test suite can be updated to lock in the new chain lengths and fixture shapes. Doing tests last means the test edits exactly mirror the authority changes, not a moving target.
+- The two test files in scope (`scripts/__tests__/orchestrating-workflows.test.ts` and `scripts/__tests__/workflow-state.test.ts`) are the only sites where chain structure is encoded as executable assertions or JSON fixtures. `scripts/__tests__/reviewing-requirements.test.ts` is untouched per FR-7 (the standalone `code-review` mode is preserved).
+- `workflow-state.sh` is not touched per NFR-3 / FR-4 (the script accepts `mode` and `decision` as free-form strings; no enum validation to update).
+
+#### Implementation Steps
+
+1. **Update `scripts/__tests__/orchestrating-workflows.test.ts` chain-table assertions (FR-8)**. Locate tests that assert the ordered sequence of step names for each chain. Remove the `'Reconcile post-review'` entry from the feature, chore, and bug step-name arrays. Confirmed occurrences: two entries in this file at lines 665 and 839 (grep-identified). Adjust any `.length` assertions accordingly (feature `6+N+5` → `6+N+4`; chore `9` → `8`; bug `9` → `8`).
+
+2. **Update the main-context-steps test (FR-8, FR-3)**. The test at line 100 reads `it('should document main-context steps (1, 5, 6+N+4)', () => {...})`. Update the test name and its body assertion to `(1, 5, 6+N+3)` to reflect the renumbering.
+
+3. **Update `stateCmd('advance CHORE-001')` fixture comments (FR-8)**. The test at line 616 has the trailing comment `// step 6: Reconcile post-review`. Remove the step entirely from the advancement sequence (the `advance` call that takes the workflow from the previous step to `Reconcile post-review`). If the test was asserting final step-index, decrement the expected value by one.
+
+4. **Update model-selection fixtures with `mode: "code-review"` (FR-8)**. Locate the entries at lines 993, 1037, 1098, 1105, and 1128 that reference `"code-review"` in orchestrator-driven fixtures (`recordSelection(id, 12, 'reviewing-requirements', 'code-review', ...)` etc.). For fixtures that simulate a fresh post-FEAT-017 orchestrator run, remove the `code-review` entry entirely. For fixtures that exist specifically to test historical compatibility (if any), leave the entry but rename the test description to clarify it is a historical-state scenario. The preferred edit is removal: the requirements' "no fixture should expect a `mode: 'code-review'` entry in `modelSelections` for a new workflow" directs to delete.
+
+5. **Update the surrounding prose comments in model-selection tests (FR-8)**. Comments at lines 1098 (`// PR creation (baseline-locked haiku) and code-review reconcile (opus post-plan).`) and 1128 (`// Post-plan non-locked entries are opus (review, plan phases × 4, code-review).`) become stale when the `code-review` entry is removed. Update each comment to describe the new expected sequence (drop `code-review reconcile` / `code-review` from the description).
+
+6. **Update `scripts/__tests__/workflow-state.test.ts` state-file fixtures (FR-8)**. At lines 180 and 291, the test fixtures include `{ name: 'Reconcile post-review', skill: 'reviewing-requirements', context: 'fork' }`. Remove these entries from the steps-array literals. If the fixture's length is relied on by assertions elsewhere in the same test block, decrement the expected length by one.
+
+7. **Update the indexed-step assertion at line 713 (FR-8)**. The test asserts `expect(steps[11].name).toBe('Reconcile post-review')`. Either remove the assertion entirely (if the test's purpose was to confirm the step existed at that index) or update it to assert the step that now occupies index 11 in the new numbering (e.g., `Execute QA` on a feature chain with N=3 phases, after the removed step is gone — `steps[11].name === 'Execute QA'`). The implementer confirms the intended post-edit step at that index by re-reading the surrounding test setup.
+
+8. **Run the test suite and iterate until green**. Execute `npm test` from the repository root. For any failing test not covered by steps 1–7, grep the failure location for `code-review`, `6+N+5`, `9`, or `Reconcile post-review` and apply the same transformations. The vitest config (`fileParallelism: false`) means tests run sequentially — fix failures in order of appearance.
+
+9. **Preserve unchanged**. `scripts/__tests__/reviewing-requirements.test.ts` must have zero edits (FR-7 / FR-8 "Preserve unchanged" clause). Confirm with `git diff --stat` for this path.
+
+#### Deliverables
+
+- [ ] `scripts/__tests__/orchestrating-workflows.test.ts` — chain-table step-name assertions updated (remove `Reconcile post-review`), chain-length assertions updated, main-context-steps test renamed `(1, 5, 6+N+3)`, `code-review` model-selection fixture entries removed, stale prose comments updated
+- [ ] `scripts/__tests__/workflow-state.test.ts` — state-file fixtures at lines 180 and 291 have `Reconcile post-review` entry removed, indexed-step assertion at line 713 updated or removed
+- [ ] `scripts/__tests__/reviewing-requirements.test.ts` — zero changes (FR-7 preservation check)
+
+#### Phase-Level Acceptance Criteria
+
+- [ ] `npm test` passes with zero failing tests
+- [ ] No test fixture or assertion contains the string `Reconcile post-review` or expects it in a chain sequence
+- [ ] No orchestrator-driven fixture writes a `mode: "code-review"` entry to `modelSelections`
+- [ ] Chain-length assertions: feature = `6 + N + 4`, chore = `8`, bug = `8`
+- [ ] `scripts/__tests__/reviewing-requirements.test.ts` has zero changes vs main
+- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` has zero changes vs main
+
+---
+
+## Shared Infrastructure
+
+No new utilities, helpers, or fixtures are created. All edits are deletions, renumberings, or narrow prose tweaks against existing files.
+
+## Files Explicitly NOT Modified (NFR-3 Compliance)
+
+Per NFR-3, the following files must remain at their pre-FEAT-017 content:
+
+- `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` — the standalone `code-review` mode is preserved (FR-7)
+- `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` — scope unchanged; still owns CR2/CR4 coverage post-removal (NFR-2)
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` — the script accepts `mode` and `decision` as free-form strings; no enum updates required (FR-4)
+- `scripts/__tests__/reviewing-requirements.test.ts` — the standalone-mode tests remain valid (FR-7, FR-8 preserve clause)
+
+Every PR in this plan must include a `git diff --stat` check (manual or CI-enforced) that no changes land in these paths.
+
+## Testing Strategy
+
+### Unit Tests (Phase 3)
+
+Vitest runs `scripts/__tests__/*.test.ts` sequentially (`fileParallelism: false`). The updated `orchestrating-workflows.test.ts` asserts:
+
+- Feature chain length = `6 + N + 4` for a synthetic N (typically N=3, giving total 13 → 12 step entries under the new numbering).
+- Chore chain length = 8.
+- Bug chain length = 8.
+- Main-context-steps test enumerates `(1, 5, 6+N+3)` — Execute QA now at `6+N+3`, not `6+N+4`.
+- Findings-handling step-index mapping: feature steps 2/6 → indices 1/5; chore/bug steps 2/4 → indices 1/3. The post-review index row is gone.
+- No orchestrator-driven model-selection fixture writes `mode: "code-review"`.
+
+The `workflow-state.test.ts` updates focus on state-file fixture shape: no `Reconcile post-review` step entry in a newly initialized workflow's `steps` array. Backwards compatibility for historical state files is implicit — the script accepts any string for `mode` and `decision`, so no assertion is required on the read side.
+
+### Integration Testing (post-merge, manual)
+
+Per the requirements' manual-testing matrix:
+
+- Run a small feature chain end-to-end. Confirm the workflow advances directly from the PR-review pause (on resume) to `executing-qa` with no intermediate `reviewing-requirements` fork. Inspect the final state file: no step entry named `Reconcile post-review`.
+- Run a small chore chain end-to-end. Confirm 8 step entries. Inspect `modelSelections`: no entry with `mode: "code-review"`.
+- Run a small bug chain end-to-end. Same expectations as the chore chain.
+- Invoke `/reviewing-requirements FEAT-016 --pr 162` (or any completed PR) manually. Confirm the `code-review` reconciliation mode still produces its findings list, validating FR-7 preservation.
+- Resume a workflow that was paused at the pre-code-review pause. Confirm the orchestrator proceeds directly to `executing-qa` without user intervention.
+
+### Backwards-Compatibility Spot Check (NFR-1)
+
+Optional but recommended: on a fork of a pre-FEAT-017 state file that contains a historical `Reconcile post-review` step entry plus a `mode: "code-review"` modelSelection, run `workflow-state.sh status {ID}`. The subcommand must return the full state including the historical entries without error. No fixture is added for this case; the existing `status` tests already cover the backwards-compatible read path.
+
+## Dependencies and Prerequisites
+
+- **FEAT-007** (code-review reconciliation mode introduction) — The standalone mode is preserved per FR-7. This work removes only the automatic orchestrator invocation.
+- **FEAT-015** (findings-handling spiral fix) — Landed. Its decision-flow logic is unchanged; only the number of call sites shrinks by one per chain.
+- **FEAT-016** (findings persistence) — Landed. The `record-findings` subcommand and its schema are unchanged; one fewer call site per chain invokes it.
+- **CHORE-031** (low-complexity skip for reviewing-requirements steps) — The skip targets chore/bug steps 2 and 4 by step-name + mode (`standard`, `test-plan`); it never applied to the removed step. No skip-logic changes required after renumbering.
+- **Tooling**: no new dependencies. `npm test` (vitest), `git`, and the existing grep tooling suffice.
+
+## Risk Assessment
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Missed downstream step-number reference leaves SKILL.md / references in an inconsistent state | Medium | Medium | Phase 1 step 14 is an explicit grep-sweep of all literal step-number tokens across both in-scope files. Phase 2 step 5 repeats the sweep for `chain-procedures.md`. |
+| A stale `Reconcile post-review` reference remains in `step-execution-details.md` because the fork-block deletion removed the header but not surrounding prose | Medium | Low | Phase 1 step 11 explicitly calls for deletion of "surrounding prose that refers to it" in addition to the fork-block body. Phase 1 acceptance criterion re-greps for `Reconcile post-review` in the two files. |
+| Tests fail after Phase 3 because a chain-length assertion relies on a magic number not identified in steps 1–7 | Low | Medium | Phase 3 step 8 instructs iterating on `npm test` failures until green. Each failing test's location is pattern-searched for the same tokens. |
+| Workflow paused at the removed step before upgrade cannot resume cleanly (NFR-1 edge case 1) | Low | Low | Accepted per the feature requirement's edge-case documentation. Release notes / CHORE changelog must document the two escape hatches (complete old-flow first, or manually edit the state file). No implementation mitigation needed in this plan. |
+| A test developer edits `reviewing-requirements.test.ts` reflexively while updating chain-length fixtures, breaking FR-7 | Low | Low | Phase 3 step 9 and the Phase 3 acceptance criterion explicitly gate on `git diff --stat` showing zero changes to that path. |
+| `model-selection.md` edit in Phase 2 over-narrows the `mode` schema enum and breaks historical state-file readers | Low | Low | Phase 2 step 6 specifies two acceptable wordings, both of which preserve `"code-review"` as a valid-value annotation. The implementer chooses wording but cannot accidentally drop the value. |
+
+## Rollback Strategy
+
+The work is pure documentation + test edits, so rollback is a `git revert` of each phase's merge commit. Because phases are logically layered (Phase 1 changes the authority, Phase 2 mirrors it, Phase 3 locks it), a partial rollback (reverting only Phase 3) would leave tests stale but would not break runtime behavior — the orchestrator still reads the updated SKILL.md. A full rollback (all three phases) restores the pre-FEAT-017 behavior exactly, since no state-schema or script changes were made.
+
+Existing workflow state files written during the FEAT-017 window remain valid under either direction (NFR-1): the script's free-form `mode` and `decision` fields accept any string, so neither the new 8-step shape nor the old 9-step shape locks out the other.
+
+## Success Criteria
+
+- [ ] All three chain step-sequence tables in `SKILL.md` reflect the new numbering (feature `6 + N + 4` total; chore `8`; bug `8`)
+- [ ] All three fork-instruction blocks for the removed step are deleted from `step-execution-details.md`
+- [ ] Downstream step numbers are renumbered consistently across `SKILL.md`, `step-execution-details.md`, `chain-procedures.md` (if applicable), and `verification-and-relationships.md`
+- [ ] Reviewing-Requirements Findings Handling scope line lists only feature steps 2/6 and chore/bug steps 2/4
+- [ ] Persisting Findings chain-step-to-index bullet lists only feature `2/6 → 1/5` and chore/bug `2/4 → 1/3`
+- [ ] Fork Step-Name Map row for `reviewing-requirements` lists only `standard / test-plan`
+- [ ] Verification checklists contain no reference to the removed step or its findings-handling
+- [ ] Skill-relationship tables list `reviewing-requirements` with only `standard` and `test-plan` modes
+- [ ] `npm test` passes
+- [ ] `git diff --stat origin/main` shows zero changes to `reviewing-requirements/SKILL.md`, `executing-qa/SKILL.md`, `workflow-state.sh`, and `reviewing-requirements.test.ts`
+- [ ] End-to-end feature, chore, and bug workflow runs produce state files with no `Reconcile post-review` step entry
+- [ ] `/reviewing-requirements {ID} --pr {prNumber}` standalone invocation still executes code-review reconciliation mode unchanged
+
+## Code Organization
+
+All edits are confined to the following paths:
+
+```
+plugins/lwndev-sdlc/skills/orchestrating-workflows/
+├── SKILL.md                                      ← Phase 1
+└── references/
+    ├── step-execution-details.md                 ← Phase 1
+    ├── verification-and-relationships.md         ← Phase 2
+    ├── chain-procedures.md                       ← Phase 2 (grep-swept; likely no edits)
+    └── model-selection.md                        ← Phase 2 (prose clarification)
+
+scripts/__tests__/
+├── orchestrating-workflows.test.ts               ← Phase 3
+└── workflow-state.test.ts                        ← Phase 3
+```
+
+No new files. No deletions at the file level (only content deletions within existing files).

--- a/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
@@ -178,10 +178,11 @@ Per NFR-3, the following files must remain at their pre-FEAT-017 content:
 
 - `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` — the standalone `code-review` mode is preserved (FR-7)
 - `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` — scope unchanged; still owns CR2/CR4 coverage post-removal (NFR-2)
-- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` — the script accepts `mode` and `decision` as free-form strings; no enum updates required (FR-4)
 - `scripts/__tests__/reviewing-requirements.test.ts` — the standalone-mode tests remain valid (FR-7, FR-8 preserve clause)
 
-Every PR in this plan must include a `git diff --stat` check (manual or CI-enforced) that no changes land in these paths.
+**Scope correction during Phase 3**: `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh` was originally listed as preserved-unchanged, on the premise that its `record-model-selection` / `record-findings` subcommands accept free-form `mode`/`decision` strings. That holds for subcommand behavior but missed the step-generation functions (`generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`) which emit the literal `Reconcile post-review` step entry during `init` / `populate-phases`. Without editing those generators, new workflows would still include the removed step in their state-file `steps` array — contradicting the feature's acceptance criteria. The script has been updated to drop the step entry from those three generator functions and update the "9-step"/"14-step" code comments to "8-step"/"13-step". The subcommand signatures remain unchanged; only the step-generation JSON heredocs were edited.
+
+Every PR in this plan must include a `git diff --stat` check (manual or CI-enforced) that no changes land in the preserved-unchanged paths above.
 
 ## Testing Strategy
 

--- a/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
+++ b/requirements/implementation/FEAT-017-remove-code-review-reconciliation-step.md
@@ -80,7 +80,7 @@ The work is partitioned into three phases that align with natural review boundar
 
 ### Phase 2: Downstream References — Verification Checklists, Relationship Tables, Chain Procedures
 **Feature:** [FEAT-017](../features/FEAT-017-remove-code-review-reconciliation-step.md) | [#147](https://github.com/lwndev/lwndev-marketplace/issues/147)
-**Status:** Pending
+**Status:** ✅ Complete
 
 #### Rationale
 
@@ -107,9 +107,9 @@ The work is partitioned into three phases that align with natural review boundar
 
 #### Deliverables
 
-- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` — verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode
-- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` — grep-swept; edits applied only if the file references the removed step or downstream step numbers
-- [ ] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` — `mode` schema prose updated to reflect the orchestrator-vs-historical distinction (FR-7, NFR-1)
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/verification-and-relationships.md` — verification checklist items referencing the removed step deleted, chain-length prose updated (`9-step` → `8-step`), skill-relationship tables updated to drop `code-review` mode
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/chain-procedures.md` — grep-swept; edits applied only if the file references the removed step or downstream step numbers
+- [x] `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/model-selection.md` — `mode` schema prose updated to reflect the orchestrator-vs-historical distinction (FR-7, NFR-1)
 
 #### Phase-Level Acceptance Criteria
 

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -576,14 +576,14 @@ describe('integration tests', () => {
   // --- Chore Chain Integration Tests ---
 
   describe('chore chain lifecycle', () => {
-    it('init → advance through all 9 steps → pause at step 5 → resume → advance remaining → complete', () => {
+    it('init → advance through all 8 steps → pause at step 5 → resume → advance remaining → complete', () => {
       // Init chore chain
       const initState = stateJSON('init CHORE-001 chore');
       expect(initState.status).toBe('in-progress');
       expect(initState.currentStep).toBe(0);
       expect(initState.type).toBe('chore');
       const initSteps = initState.steps as Array<Record<string, unknown>>;
-      expect(initSteps).toHaveLength(9);
+      expect(initSteps).toHaveLength(8);
 
       // Advance steps 0-4 (Document chore through Execute chore)
       stateCmd('advance CHORE-001 "requirements/chores/CHORE-001-test.md"'); // step 0: Document chore
@@ -611,11 +611,10 @@ describe('integration tests', () => {
       expect(resumeState.pauseReason).toBeNull();
       expect(resumeState.lastResumedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
-      // Advance steps 5-8 (PR review through Finalize)
+      // Advance steps 5-7 (PR review through Finalize)
       stateCmd('advance CHORE-001'); // step 5: PR review
-      stateCmd('advance CHORE-001'); // step 6: Reconcile post-review
-      stateCmd('advance CHORE-001'); // step 7: Execute QA
-      stateCmd('advance CHORE-001'); // step 8: Finalize
+      stateCmd('advance CHORE-001'); // step 6: Execute QA
+      stateCmd('advance CHORE-001'); // step 7: Finalize
 
       // Complete
       const completeState = stateJSON('complete CHORE-001');
@@ -624,7 +623,7 @@ describe('integration tests', () => {
 
       // Verify all steps are complete
       const finalSteps = completeState.steps as Array<Record<string, unknown>>;
-      for (let i = 0; i < 9; i++) {
+      for (let i = 0; i < 8; i++) {
         expect(finalSteps[i].status).toBe('complete');
       }
     });
@@ -642,19 +641,19 @@ describe('integration tests', () => {
   });
 
   describe('chore chain has no phase loop', () => {
-    it('state file has exactly 9 steps from init with no dynamic insertion needed', () => {
+    it('state file has exactly 8 steps from init with no dynamic insertion needed', () => {
       const state = stateJSON('init CHORE-001 chore');
       const steps = state.steps as Array<Record<string, unknown>>;
 
-      // Exactly 9 steps — no populate-phases needed
-      expect(steps).toHaveLength(9);
+      // Exactly 8 steps — no populate-phases needed
+      expect(steps).toHaveLength(8);
 
       // Verify no step has phaseNumber (no phase loop steps)
       for (const step of steps) {
         expect(step).not.toHaveProperty('phaseNumber');
       }
 
-      // Verify step names match the fixed 9-step sequence
+      // Verify step names match the fixed 8-step sequence
       const expectedNames = [
         'Document chore',
         'Review requirements (standard)',
@@ -662,11 +661,10 @@ describe('integration tests', () => {
         'Reconcile test plan',
         'Execute chore',
         'PR review',
-        'Reconcile post-review',
         'Execute QA',
         'Finalize',
       ];
-      for (let i = 0; i < 9; i++) {
+      for (let i = 0; i < 8; i++) {
         expect(steps[i].name).toBe(expectedNames[i]);
       }
     });
@@ -764,10 +762,10 @@ describe('integration tests', () => {
   });
 
   describe('bug chain lifecycle', () => {
-    it('init → advance through all 9 steps → pause at step 5 → resume → advance remaining → complete', () => {
+    it('init → advance through all 8 steps → pause at step 5 → resume → advance remaining → complete', () => {
       const initState = stateJSON('init BUG-001 bug');
       expect(initState.type).toBe('bug');
-      expect(initState.steps).toHaveLength(9);
+      expect(initState.steps).toHaveLength(8);
 
       // Advance steps 0-4
       stateCmd('advance BUG-001');
@@ -793,8 +791,7 @@ describe('integration tests', () => {
       expect(resumedState.status).toBe('in-progress');
       expect(resumedState.lastResumedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
-      // Advance remaining steps 5-8
-      stateCmd('advance BUG-001');
+      // Advance remaining steps 5-7
       stateCmd('advance BUG-001');
       stateCmd('advance BUG-001');
       stateCmd('advance BUG-001');
@@ -805,7 +802,7 @@ describe('integration tests', () => {
       expect(completedState.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
       const finalSteps = completedState.steps as Array<Record<string, unknown>>;
-      for (let i = 0; i < 9; i++) {
+      for (let i = 0; i < 8; i++) {
         expect(finalSteps[i].status).toBe('complete');
       }
     });
@@ -823,11 +820,11 @@ describe('integration tests', () => {
   });
 
   describe('bug chain has no phase loop', () => {
-    it('state file has exactly 9 steps from init with no dynamic insertion needed', () => {
+    it('state file has exactly 8 steps from init with no dynamic insertion needed', () => {
       const state = stateJSON('init BUG-001 bug');
       const steps = state.steps as Array<Record<string, unknown>>;
 
-      expect(steps).toHaveLength(9);
+      expect(steps).toHaveLength(8);
 
       const expectedNames = [
         'Document bug',
@@ -836,11 +833,10 @@ describe('integration tests', () => {
         'Reconcile test plan',
         'Execute bug fix',
         'PR review',
-        'Reconcile post-review',
         'Execute QA',
         'Finalize',
       ];
-      for (let i = 0; i < 9; i++) {
+      for (let i = 0; i < 8; i++) {
         expect(steps[i].name).toBe(expectedNames[i]);
       }
     });

--- a/scripts/__tests__/orchestrating-workflows.test.ts
+++ b/scripts/__tests__/orchestrating-workflows.test.ts
@@ -97,7 +97,7 @@ describe('orchestrating-workflows skill', () => {
       expect(skillMd).toContain('finalizing-workflow');
     });
 
-    it('should document main-context steps (1, 5, 6+N+4)', () => {
+    it('should document main-context steps (1, 5, 6+N+3)', () => {
       expect(skillMd).toContain('Main-Context Steps');
       expect(skillMd).toContain('main');
     });
@@ -985,12 +985,13 @@ describe('integration tests', () => {
         stateCmd(`set-complexity ${id} ${initTier}`);
 
         // Every chore-chain fork step and its expected tier per Example A.
+        // Post-FEAT-017: the code-review reconcile fork is removed from the
+        // orchestrated chain, so this fixture no longer writes that entry.
         const forkSteps: Array<[number, string, string, string]> = [
           // [stepIndex, step-name, mode, expected tier]
           [1, 'reviewing-requirements', 'standard', 'sonnet'],
           [3, 'reviewing-requirements', 'test-plan', 'sonnet'],
           [4, 'executing-chores', 'null', 'sonnet'],
-          [6, 'reviewing-requirements', 'code-review', 'sonnet'],
           [8, 'finalizing-workflow', 'null', 'haiku'],
         ];
 
@@ -1002,14 +1003,14 @@ describe('integration tests', () => {
 
         const finalState = stateJSON(`status ${id}`);
         const selections = finalState.modelSelections as Array<Record<string, unknown>>;
-        expect(selections).toHaveLength(5);
+        expect(selections).toHaveLength(4);
 
         // Zero Opus tier invocations.
         const opusCount = selections.filter((s) => s.tier === 'opus').length;
         expect(opusCount).toBe(0);
 
         // All non-final forks at sonnet; finalizing at haiku.
-        expect(selections.filter((s) => s.tier === 'sonnet')).toHaveLength(4);
+        expect(selections.filter((s) => s.tier === 'sonnet')).toHaveLength(3);
         expect(selections.filter((s) => s.tier === 'haiku')).toHaveLength(1);
 
         // Every audit entry is stamped with init stage (chore chains never upgrade).
@@ -1030,11 +1031,12 @@ describe('integration tests', () => {
         stateCmd(`set-complexity ${id} ${initTier}`);
 
         // Bug-chain fork steps per Example B.
+        // Post-FEAT-017: the code-review reconcile fork is removed from the
+        // orchestrated chain, so this fixture no longer writes that entry.
         const forkSteps: Array<[number, string, string, string]> = [
           [1, 'reviewing-requirements', 'standard', 'sonnet'],
           [3, 'reviewing-requirements', 'test-plan', 'sonnet'],
           [4, 'executing-bug-fixes', 'null', 'sonnet'],
-          [6, 'reviewing-requirements', 'code-review', 'sonnet'],
           [8, 'finalizing-workflow', 'null', 'haiku'],
         ];
 
@@ -1046,9 +1048,9 @@ describe('integration tests', () => {
 
         const finalState = stateJSON(`status ${id}`);
         const selections = finalState.modelSelections as Array<Record<string, unknown>>;
-        expect(selections).toHaveLength(5);
+        expect(selections).toHaveLength(4);
         expect(selections.filter((s) => s.tier === 'opus')).toHaveLength(0);
-        expect(selections.filter((s) => s.tier === 'sonnet')).toHaveLength(4);
+        expect(selections.filter((s) => s.tier === 'sonnet')).toHaveLength(3);
         expect(selections.filter((s) => s.tier === 'haiku')).toHaveLength(1);
       });
     });
@@ -1095,14 +1097,12 @@ describe('integration tests', () => {
           recordSelection(id, 5 + phase, 'implementing-plan-phases', 'null', String(phase), tPhase);
         }
 
-        // PR creation (baseline-locked haiku) and code-review reconcile (opus post-plan).
+        // PR creation (baseline-locked haiku).
+        // Post-FEAT-017: the code-review reconcile fork has been removed from
+        // the orchestrated chain, so no 'code-review' entry is recorded here.
         const tPr = resolveTier(id, 'pr-creation');
         expect(tPr).toBe('haiku');
         recordSelection(id, 10, 'pr-creation', 'null', 'null', tPr);
-
-        const tReconcile = resolveTier(id, 'reviewing-requirements');
-        expect(tReconcile).toBe('opus');
-        recordSelection(id, 12, 'reviewing-requirements', 'code-review', 'null', tReconcile);
 
         // Finalize (baseline-locked haiku).
         const tFinal = resolveTier(id, 'finalizing-workflow');
@@ -1112,24 +1112,24 @@ describe('integration tests', () => {
         // Audit trail assertions.
         const finalState = stateJSON(`status ${id}`);
         const selections = finalState.modelSelections as Array<Record<string, unknown>>;
-        expect(selections).toHaveLength(10);
+        expect(selections).toHaveLength(9);
 
         // Steps 2 and 3 are init-stage; everything after post-plan recomputation is post-plan.
         const initEntries = selections.filter((s) => s.complexityStage === 'init');
         const postPlanEntries = selections.filter((s) => s.complexityStage === 'post-plan');
         expect(initEntries).toHaveLength(2);
-        expect(postPlanEntries).toHaveLength(8);
+        expect(postPlanEntries).toHaveLength(7);
 
         // Init entries are sonnet (baseline floor).
         for (const s of initEntries) {
           expect(s.tier).toBe('sonnet');
         }
 
-        // Post-plan non-locked entries are opus (review, plan phases × 4, code-review).
+        // Post-plan non-locked entries are opus (review, plan phases × 4).
         const nonLockedPostPlan = postPlanEntries.filter(
           (s) => s.skill !== 'finalizing-workflow' && s.skill !== 'pr-creation'
         );
-        expect(nonLockedPostPlan).toHaveLength(6);
+        expect(nonLockedPostPlan).toHaveLength(5);
         for (const s of nonLockedPostPlan) {
           expect(s.tier).toBe('opus');
         }

--- a/scripts/__tests__/workflow-state.test.ts
+++ b/scripts/__tests__/workflow-state.test.ts
@@ -130,7 +130,7 @@ describe('workflow-state.sh', () => {
     it('accepts bug chain type', () => {
       const state = runJSON('init BUG-001 bug');
       expect(state.type).toBe('bug');
-      expect(state.steps).toHaveLength(9);
+      expect(state.steps).toHaveLength(8);
     });
 
     it('rejects unknown chain types', () => {
@@ -160,11 +160,11 @@ describe('workflow-state.sh', () => {
   });
 
   describe('chore chain', () => {
-    it('generate_chore_steps produces exactly 9 steps with correct names, skills, and contexts', () => {
+    it('generate_chore_steps produces exactly 8 steps with correct names, skills, and contexts', () => {
       const state = runJSON('init CHORE-001 chore');
       const steps = state.steps as Array<Record<string, unknown>>;
 
-      expect(steps).toHaveLength(9);
+      expect(steps).toHaveLength(8);
 
       const expected = [
         { name: 'Document chore', skill: 'documenting-chores', context: 'main' },
@@ -177,7 +177,6 @@ describe('workflow-state.sh', () => {
         { name: 'Reconcile test plan', skill: 'reviewing-requirements', context: 'fork' },
         { name: 'Execute chore', skill: 'executing-chores', context: 'fork' },
         { name: 'PR review', skill: null, context: 'pause' },
-        { name: 'Reconcile post-review', skill: 'reviewing-requirements', context: 'fork' },
         { name: 'Execute QA', skill: 'executing-qa', context: 'main' },
         { name: 'Finalize', skill: 'finalizing-workflow', context: 'fork' },
       ];
@@ -205,7 +204,7 @@ describe('workflow-state.sh', () => {
       expect(state.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(state.lastResumedAt).toBeNull();
       expect(state.phases).toEqual({ total: 0, completed: 0 });
-      expect(state.steps).toHaveLength(9);
+      expect(state.steps).toHaveLength(8);
     });
 
     it('all state commands work with chore chain state files', () => {
@@ -271,11 +270,11 @@ describe('workflow-state.sh', () => {
   });
 
   describe('bug chain', () => {
-    it('generate_bug_steps produces exactly 9 steps with correct names, skills, and contexts', () => {
+    it('generate_bug_steps produces exactly 8 steps with correct names, skills, and contexts', () => {
       const state = runJSON('init BUG-001 bug');
       const steps = state.steps as Array<Record<string, unknown>>;
 
-      expect(steps).toHaveLength(9);
+      expect(steps).toHaveLength(8);
 
       const expected = [
         { name: 'Document bug', skill: 'documenting-bugs', context: 'main' },
@@ -288,7 +287,6 @@ describe('workflow-state.sh', () => {
         { name: 'Reconcile test plan', skill: 'reviewing-requirements', context: 'fork' },
         { name: 'Execute bug fix', skill: 'executing-bug-fixes', context: 'fork' },
         { name: 'PR review', skill: null, context: 'pause' },
-        { name: 'Reconcile post-review', skill: 'reviewing-requirements', context: 'fork' },
         { name: 'Execute QA', skill: 'executing-qa', context: 'main' },
         { name: 'Finalize', skill: 'finalizing-workflow', context: 'fork' },
       ];
@@ -316,7 +314,7 @@ describe('workflow-state.sh', () => {
       expect(state.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(state.lastResumedAt).toBeNull();
       expect(state.phases).toEqual({ total: 0, completed: 0 });
-      expect(state.steps).toHaveLength(9);
+      expect(state.steps).toHaveLength(8);
     });
 
     it('all state commands work with bug chain state files', () => {
@@ -696,8 +694,8 @@ describe('workflow-state.sh', () => {
       const state = runJSON('populate-phases FEAT-001 3');
 
       const steps = state.steps as Array<Record<string, unknown>>;
-      // 6 initial + 3 phase + 5 post-phase = 14
-      expect(steps).toHaveLength(14);
+      // 6 initial + 3 phase + 4 post-phase = 13
+      expect(steps).toHaveLength(13);
 
       // Phase steps at indices 6, 7, 8
       expect(steps[6].name).toBe('Implement phase 1 of 3');
@@ -707,12 +705,11 @@ describe('workflow-state.sh', () => {
       expect(steps[8].name).toBe('Implement phase 3 of 3');
       expect(steps[8].phaseNumber).toBe(3);
 
-      // Post-phase steps at indices 9-13
+      // Post-phase steps at indices 9-12
       expect(steps[9].name).toBe('Create PR');
       expect(steps[10].name).toBe('PR review');
-      expect(steps[11].name).toBe('Reconcile post-review');
-      expect(steps[12].name).toBe('Execute QA');
-      expect(steps[13].name).toBe('Finalize');
+      expect(steps[11].name).toBe('Execute QA');
+      expect(steps[12].name).toBe('Finalize');
     });
 
     it('sets phases.total to the count', () => {
@@ -729,8 +726,8 @@ describe('workflow-state.sh', () => {
       // Second call should be a no-op
       const state = runJSON('populate-phases FEAT-001 5');
       const steps = state.steps as Array<Record<string, unknown>>;
-      // Should still have 14 steps (3 phases), not 16 (5 phases)
-      expect(steps).toHaveLength(14);
+      // Should still have 13 steps (3 phases), not 15 (5 phases)
+      expect(steps).toHaveLength(13);
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove the advisory-only code-review reconciliation step (feature `6+N+3`, chore/bug `7`) from the `orchestrating-workflows` chain tables, fork-instruction blocks, findings-handling scope, and `workflow-state.sh` step generators. Every orchestrated run previously paid a fork + model call + findings round-trip for output the step declared advisory and deferred to `executing-qa`.
- Renumber downstream steps consistently across `SKILL.md`, `references/step-execution-details.md`, `references/verification-and-relationships.md`, and `references/model-selection.md`. Feature chain is now `6 + N + 4` steps; chore and bug chains are 8 steps each.
- Preserve the `reviewing-requirements` code-review mode as a standalone capability — users can still invoke `/reviewing-requirements {ID} --pr {N}` manually. `executing-qa`'s verification loop (supersedes CR2) and reconciliation loop (supersedes CR4) continue to own all post-PR reconciliation work.

Closes #147

## Changes by phase

| Phase | Commit | Scope |
|-------|--------|-------|
| 1 | 4fe1afa | `SKILL.md` + `step-execution-details.md` — chain tables, fork blocks, findings-handling scope, fork step-name map, mode-argument prose, chain-step-to-index bullet |
| 2 | b31eb19 | `verification-and-relationships.md` checklists + relationship tables + `8-step` prose; `model-selection.md` mode-enum clarification (`"code-review"` retained as historical/manual value) |
| 3 | 1c227cd | `orchestrating-workflows.test.ts` — main-context step rename `(1, 5, 6+N+3)`, model-selection fixtures for Examples A/B/C updated to drop `"code-review"` entries |
| 3 fixup | b188ab6 | `workflow-state.sh` step generators (`generate_chore_steps`, `generate_bug_steps`, `generate_post_phase_steps`) drop `Reconcile post-review`; matching test fixtures updated |

## Files explicitly NOT modified

- `plugins/lwndev-sdlc/skills/reviewing-requirements/SKILL.md` — standalone code-review mode preserved (FR-7)
- `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` — scope unchanged
- `scripts/__tests__/reviewing-requirements.test.ts` — standalone-mode tests remain valid

## Test plan

- [x] `npm test` — 752/752 passing across 24 test files
- [x] `npm run lint` — clean
- [x] `prettier --check scripts/` — clean
- [x] `npm run validate` — all 13 skills pass
- [x] `git diff --stat main` for preserved paths shows zero changes
- [ ] Manual: run a new feature workflow end-to-end after merge; confirm no `Reconcile post-review` step entry in state
- [ ] Manual: run a new chore workflow end-to-end after merge; confirm 8 step entries
- [ ] Manual: invoke `/reviewing-requirements FEAT-016 --pr 162` (or any completed PR); confirm code-review mode still runs standalone

## Notes

- **Scope correction**: The original requirements listed `workflow-state.sh` as preserved-unchanged. Phase 3 implementation surfaced that its `generate_chore_steps` / `generate_bug_steps` / `generate_post_phase_steps` functions are the runtime source of truth for step generation — not the SKILL.md chain tables alone. Without editing those generators, new workflows would still emit the removed step to state, contradicting the acceptance criteria. The scope was corrected during Phase 3 (commit b188ab6). The `record-model-selection` / `record-findings` subcommand signatures are unchanged.
- **Backwards compatibility (NFR-1)**: Existing state files containing historical `"Reconcile post-review"` step entries or `mode: "code-review"` selections remain valid and queryable via `workflow-state.sh status`. No migration required.
- **Workflow paused at the removed step (Edge Case 1)**: Users with a workflow paused at the old step 6+N+3 / step 7 before merging this PR must either complete on the old flow first, or hand-edit the state file to drop the step entry and advance past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)