### PR TITLE
release(lwndev-sdlc): v1.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.10.0"
+      "version": "1.11.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.11.0] - 2026-04-19
+
+### Features
+
+- **FEAT-017:** Orchestrated workflows no longer fork a second `reviewing-requirements` subagent after PR review — `executing-qa` handles post-PR reconciliation instead ([#147](https://github.com/lwndev/lwndev-marketplace/issues/147)). The `reviewing-requirements` code-review mode remains callable standalone via `/reviewing-requirements {ID} --pr {N}` for ad-hoc drift reports. Existing workflow state files with historical `Reconcile post-review` step entries or `mode: "code-review"` audit-trail entries remain valid and queryable — no migration required. (Feature chain: one fewer step; chore/bug chains: 9 → 8 steps.)
+
+### Chores
+
+- **CHORE-033:** Fix skill permission prompts in plugin configuration.
+
+[1.11.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.10.0...lwndev-sdlc@1.11.0
+
 ## [1.10.0] - 2026-04-18
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.10.0 | **Released:** 2026-04-18
+**Version:** 1.11.0 | **Released:** 2026-04-19
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Release `lwndev-sdlc@1.11.0` — minor bump from `1.10.0`.

## Highlights

### Features
- **FEAT-017** — Remove the advisory code-review reconciliation step from the orchestrator ([#147](https://github.com/lwndev/lwndev-marketplace/issues/147)). Feature chains shrink from `6+N+5` to `6+N+4` steps; chore and bug chains shrink from 9 to 8 steps. The `reviewing-requirements` code-review mode remains callable standalone via `/reviewing-requirements {ID} --pr {N}`.

### Chores
- **CHORE-033** — Fix skill permission prompts in plugin configuration.

## Backwards Compatibility

Existing workflow state files with historical `Reconcile post-review` step entries or `mode: "code-review"` audit-trail entries remain valid and queryable (NFR-1). No migration required.

**Edge case**: Workflows paused at the removed step (`6+N+3` on feature, step 7 on chore/bug) before upgrade must either complete on the old flow or hand-edit the state file — documented in the FEAT-017 requirements doc.

## Release artifacts

- [x] `plugins/lwndev-sdlc/.claude-plugin/plugin.json` — version bumped
- [x] `.claude-plugin/marketplace.json` — version bumped
- [x] `plugins/lwndev-sdlc/CHANGELOG.md` — 1.11.0 section added with refined user-facing summary
- [x] `plugins/lwndev-sdlc/README.md` — version line updated

## Test plan

- [x] Versions consistent across plugin.json, marketplace.json, and README
- [x] Changelog reads as user-facing summary (refined from auto-generated output)
- [x] FEAT-017 and CHORE-033 both represented
- [ ] After merge: run `npm run release:tag -- --plugin lwndev-sdlc` to create the `lwndev-sdlc@1.11.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)