### PR TITLE
release(lwndev-sdlc): v1.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.12.0"
+      "version": "1.12.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.12.1] - 2026-04-20
+
+### Documentation
+
+- Plugin README, root README, and CLAUDE.md refreshed to reflect the v1.12.0 state: the two new skills (`managing-work-items`, `orchestrating-workflows`) and second agent (`qa-reconciliation-agent`) shipped via FEAT-018 are now listed; the shared library inventory, release/test-skill scripts, and full npm command set are documented; and the workflow chain diagrams now show the reconciliation steps in their correct positions.
+
+[1.12.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.12.0...lwndev-sdlc@1.12.1
+
 ## [1.12.0] - 2026-04-19
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.12.0 | **Released:** 2026-04-19
+**Version:** 1.12.1 | **Released:** 2026-04-20
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release covering documentation refresh that brings the plugin README, root README, and CLAUDE.md back in sync with the v1.12.0 plugin state.

## Changes

- Plugin README, root README, and CLAUDE.md now list the two new skills (`managing-work-items`, `orchestrating-workflows`) and second agent (`qa-reconciliation-agent`) that shipped via FEAT-018.
- Documented the `plugin-manifest.ts` and `git-utils.ts` shared libs and the `release.ts` / `release-tag.ts` / `test-skill.ts` scripts, plus the full npm command set.
- Refreshed the workflow chain diagrams to show reconciliation steps in their correct positions.

No code changes — purely documentation. Bumped to 1.12.1 because the plugin README ships with the install and is therefore user-facing.

## Test plan

- [x] `npm run validate` — 13/13 skills pass
- [x] `npm test` — 846 tests pass (run by pre-commit hook)
- [x] Version values consistent across `plugin.json`, `marketplace.json`, plugin `README.md`
- [ ] After merge: run `/releasing-plugins` (Phase 2) to tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)