### PR TITLE
release(lwndev-sdlc): v1.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.12.1"
+      "version": "1.13.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.13.0] - 2026-04-20
+
+### Features
+
+- **FEAT-019:** `finalizing-workflow` gains a `## Pre-Merge Bookkeeping` section that performs four mechanical updates to the active requirement document before `gh pr merge` runs ([#169](https://github.com/lwndev/lwndev-marketplace/issues/169)). The skill derives the work-item ID from the current branch name (`feat/FEAT-*`, `chore/CHORE-*`, `fix/BUG-*`), locates the matching requirement doc via glob, and — unless the doc is already finalized (idempotency check) — flips `## Acceptance Criteria` checkboxes from `[ ]` to `[x]`, upserts a `## Completion` block with today's UTC date and the PR link, and reconciles `## Affected Files` against `gh pr view --json files` (additions appended; drops annotated `(planned but not modified)`). Bookkeeping produces a single `chore({ID}): finalize requirement document` commit and pushes it before merge; non-matching branch names and missing docs skip bookkeeping gracefully (benign skip), while push failure aborts the merge. `allowed-tools` frontmatter gains `Edit` and `Glob` to support the new work. BK-3 and BK-4 are defined to be line-ending-agnostic (handle both `\n` and `\r\n`) and fenced-code-block aware (illustrative `- [ ]` examples and `## Acceptance Criteria` headings inside fenced blocks are correctly ignored) — these robustness rules were validated by the adversarial QA run that shipped alongside the feature.
+- **FEAT-019:** New `scripts/__tests__/finalizing-workflow.test.ts` with 66 tests covering SKILL.md structural shape, unit-level correctness of the bookkeeping helpers (branch parsing, glob resolution, idempotency, AC checkoff, Completion upsert, Affected Files reconciliation, commit-message format), and end-to-end integration scenarios (happy path, idempotency re-run, `gh` partial failure, `gh` total failure, push-failure abort, non-matching-branch skip). Complements the adversarial spec `qa-finalizing-workflow-inputs.spec.ts` (14 P0 Inputs tests surfacing CRLF and fenced-code boundary cases).
+
+### Scope notes
+
+- `executing-qa/SKILL.md` is unchanged by this release. The pre-FEAT-018 write-back reconciliation loop it used to contain was already removed in v1.12.0; FEAT-019 does not reintroduce any `executing-qa` edits.
+- The bookkeeping behavior applies only to workflows whose branch names follow the canonical `feat/FEAT-*-`, `chore/CHORE-*-`, or `fix/BUG-*-` conventions. Release branches (`release/...`) are intentionally skipped so the plugin's own releases do not attempt to bookkeep themselves.
+
+[1.13.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.12.1...lwndev-sdlc@1.13.0
+
 ## [1.12.1] - 2026-04-20
 
 ### Documentation

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.12.1 | **Released:** 2026-04-20
+**Version:** 1.13.0 | **Released:** 2026-04-20
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

- Bumps `lwndev-sdlc` from 1.12.1 → 1.13.0
- Ships FEAT-019: `finalizing-workflow` gains a `## Pre-Merge Bookkeeping` section that performs four mechanical requirement-doc updates (AC checkoff, Completion upsert with PR link, Affected Files reconciliation) before `gh pr merge` runs
- Ships a 66-test suite for the new skill behavior plus a 14-test adversarial QA spec that validates the line-ending- and fence-aware robustness rules

## Test plan

- [x] `npm run validate` passes
- [x] `npm test` passes (926 tests)
- [ ] Manual: install the released plugin via `/plugin install lwndev-sdlc@lwndev-plugins` after tagging and confirm the `## Pre-Merge Bookkeeping` section is present in the installed `finalizing-workflow/SKILL.md`
- [ ] Manual: run a small chore or bug workflow end-to-end using the released plugin; verify the requirement doc post-merge has ticked ACs, a Completion block with today's date + PR link, and a reconciled Affected Files list
- [ ] Manual: run `/finalizing-workflow` on a `release/*` branch (e.g., this one after it's reused for a later bump); verify bookkeeping is skipped with an info-level message and merge proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)