### PR TITLE
fix(FEAT-020): disable patsub_replacement for create-pr.sh body substitution

### DIFF
--- a/plugins/lwndev-sdlc/scripts/create-pr.sh
+++ b/plugins/lwndev-sdlc/scripts/create-pr.sh
@@ -29,6 +29,12 @@
 
 set -euo pipefail
 
+# Bash 5.2+ enables patsub_replacement by default, which makes `&' in the
+# replacement of `${var//pat/rep}` refer to the matched text. We rely on
+# `&' staying literal when substituting user-supplied summaries that may
+# contain ampersands; disable the shopt here (no-op on older bash).
+shopt -u patsub_replacement 2>/dev/null || true
+
 usage() {
   echo "error: usage: create-pr.sh <type> <ID> <summary> [--closes <issueRef>]" >&2
   exit 2
@@ -118,8 +124,9 @@ generated_with='🤖 Generated with [Claude Code](https://claude.com/claude-code
 
 # Perform placeholder substitution via bash parameter expansion.
 # The literal placeholder in the template is `${VAR}`; we replace it as a fixed
-# string (no pattern interpretation). This is safe for all characters in the
-# replacement values because bash ${var//pat/rep} does not re-interpret `rep`.
+# string (no pattern interpretation). Bash 5.2+ adds `patsub_replacement` which
+# would re-interpret `&' in the replacement as the matched text — we disable it
+# at the top of this script so `&' stays literal in user-supplied summaries.
 body="$tmpl_body"
 body="${body//\$\{TYPE\}/$type}"
 body="${body//\$\{ID\}/$id}"

--- a/plugins/lwndev-sdlc/scripts/tests/create-pr.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/create-pr.bats
@@ -171,3 +171,17 @@ teardown() {
   [ "$status" -eq 0 ]
   grep -qF "Closes #7" "${STUBDIR}/gh.body"
 }
+
+@test "summary with '&' survives body substitution (bash 5.2+ patsub_replacement guard)" {
+  # Regression guard: bash 5.2 enables patsub_replacement by default, which
+  # makes `&' in the replacement of `${var//pat/rep}` refer to the matched
+  # text. create-pr.sh disables that shopt at entry so user-supplied summaries
+  # containing `&' stay literal. If someone removes the shopt line, this test
+  # catches the regression even before the vitest qa scenario runs.
+  run bash "$CREATE_PR" feat FEAT-020 "tests & fixtures & more"
+  [ "$status" -eq 0 ]
+  grep -qF "tests & fixtures & more" "${STUBDIR}/gh.body"
+  # And make sure the body does not contain any leaked placeholder fragment
+  # that would indicate the `&' re-expanded into the matched `${SUMMARY}`.
+  ! grep -qF '${SUMMARY}' "${STUBDIR}/gh.body"
+}


### PR DESCRIPTION
## Summary

Disables `shopt patsub_replacement` at the top of `create-pr.sh` so the body-template substitution works correctly on bash 5.2+.

Bash 5.2 (shipped on ubuntu-latest) enabled `patsub_replacement` by default, which makes `&` in the replacement of `\${var//pat/rep}` refer to the matched text (sed-style). `create-pr.sh` relies on `&` staying literal when substituting user-supplied summaries that may contain ampersands; without this fix, those ampersands corrupt the PR body into fragments of the original `\${SUMMARY}` placeholder.

Caught by the qa-FEAT-020 shell-metacharacter-safety scenario on CI ([failed run](https://github.com/lwndev/lwndev-marketplace/actions/runs/24702019089)). macOS bash 3.2 does not recognize the shopt, so the bug was invisible on local dev and slipped through the PR #193 review. The shopt call is suppressed with `2>/dev/null || true`, so it remains a no-op on older bash.

## Test plan

- [x] `shellcheck -S warning plugins/lwndev-sdlc/scripts/create-pr.sh` — clean
- [x] `bats plugins/lwndev-sdlc/scripts/tests/create-pr.bats` — 11/11 pass locally
- [x] `npm test` — 982/982 pass locally
- [ ] CI turns green on this branch (verified by the job this PR kicks off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)