### PR TITLE
release(lwndev-sdlc): v1.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.13.0"
+      "version": "1.14.0"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.14.0] - 2026-04-21
+
+### Features
+
+- **FEAT-020:** New `plugins/lwndev-sdlc/scripts/` plugin-shared script layer with ten cross-cutting shell utilities ([#180](https://github.com/lwndev/lwndev-marketplace/issues/180)): `next-id.sh` (ID allocation), `slugify.sh` (title → kebab slug, stopword-aware), `resolve-requirement-doc.sh` (ID → doc path), `build-branch-name.sh` (type/ID/summary → canonical branch name), `ensure-branch.sh` (create-or-switch with dirty-tree guard), `check-acceptance.sh` (fence-aware single-checkbox flip with literal-substring matching), `checkbox-flip-all.sh` (fence-aware section-wide flip with CRLF-preserving rewrite), `commit-work.sh` (conventional-commit emitter — caller stages), `create-pr.sh` (push + `gh pr create` with envsubst-free `pr-body.tmpl` template), and `branch-id-parse.sh` (branch-name → `{id, type, dir}` JSON with `jq`-absent fallback). Each script has a `bats` fixture under `scripts/tests/` covering happy path, documented error exits, idempotency, fence-awareness, CRLF tolerance, and shell-metacharacter safety; the full suite is green under `shellcheck -S warning` and bash 3.2 (macOS default) and 5.2+ (Ubuntu CI).
+- **FEAT-020:** Eleven consumer skill SKILL.md files now invoke these scripts as one-line `bash "${CLAUDE_PLUGIN_ROOT}/scripts/<name>.sh" …` calls, replacing the 80–400-token prose recipes they previously duplicated. Adopters: `documenting-features`, `documenting-chores`, `documenting-bugs` (AC-11 next-id, AC-12 slugify); `reviewing-requirements` × 3 modes, `creating-implementation-plans`, `implementing-plan-phases`, `executing-chores`, `executing-bug-fixes`, `executing-qa`, `finalizing-workflow` (AC-13 resolve-requirement-doc); `implementing-plan-phases`, `executing-chores`, `executing-bug-fixes` (AC-14 build-branch-name, AC-15 ensure-branch); plus targeted replacements for `check-acceptance.sh`, `checkbox-flip-all.sh`, `commit-work.sh`, `create-pr.sh`, and `branch-id-parse.sh` in the skills that need them. The orchestrator's resume-from-branch fallback also uses `branch-id-parse.sh`.
+- **FEAT-020:** New `scripts/__tests__/shared-scripts.test.ts` vitest integration suite (35 cases) asserting filesystem-level invariants — directory layout, executable-bit on every script, usage-error sanity via `spawnSync`, `pr-body.tmpl` asset presence, and a one-to-one script-to-bats-fixture count. A companion adversarial suite `scripts/__tests__/qa-FEAT-020.spec.ts` (21 cases) probes CRLF round-trip preservation, language-tagged/tilde-fence awareness, regex-metachar literal matching, concurrent `next-id.sh` invocation, shell-metacharacter safety in body substitution, `jq`-absent fallback, symlinked `${BASH_SOURCE%/*}` resolution, and non-default-locale handling.
+
+### Bug Fixes
+
+- **FEAT-020:** `checkbox-flip-all.sh` now detects the input file's line-ending style on read and restores it on write (per the FEAT-019 "normalize on read and restore the original ending on write" rule). The initial implementation stripped CRLFs before the awk rewrite, silently downgrading Windows-authored docs to LF; this is fixed and backed by QA round-trip scenarios in `qa-FEAT-020.spec.ts`.
+- **FEAT-020:** `create-pr.sh` disables the `patsub_replacement` shopt at entry so literal `&` in user-supplied summaries survives body substitution on bash 5.2+ (Ubuntu CI default). Without this guard, bash 5.2's new sed-style `&` semantics re-expand ampersands into the matched `${SUMMARY}` placeholder and corrupt the PR body. A dedicated `bats` case and the qa shell-metacharacter-safety scenario both assert the fix.
+
+### Scope notes
+
+- `plugin.json` and this CHANGELOG are the release-surface changes. No skill frontmatter changes; no new or renamed skills; no agent changes.
+- Consumer skills that adopted the shared scripts retain identical observable behaviour — only prose is replaced with an equivalent `bash` invocation. Any workflow that worked against v1.13.0 continues to work against v1.14.0.
+
+[1.14.0]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.13.0...lwndev-sdlc@1.14.0
+
 ## [1.13.0] - 2026-04-20
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.13.0 | **Released:** 2026-04-20
+**Version:** 1.14.0 | **Released:** 2026-04-21
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Cuts `lwndev-sdlc` v1.14.0, carrying the FEAT-020 plugin-shared scripts library and its two post-merge hot-fixes.

**Headline:** Introduces `plugins/lwndev-sdlc/scripts/` with ten cross-cutting shell utilities (ID allocation, slugging, requirement-doc resolution, branch surgery, fence-aware checkbox flipping, commit/PR emission, branch classification) plus a `pr-body.tmpl` asset. Eleven adopter SKILL.md files replace their duplicated 80–400-token prose recipes with one-line `bash "${CLAUDE_PLUGIN_ROOT}/scripts/<name>.sh" …` calls. Covered by 95 bats fixtures and a 35-case vitest integration suite; an additional 21-case adversarial qa suite probes failure modes beyond the authoring bats (CRLF round-trip, fence edge cases, shell-metacharacter safety, jq-absent fallback, concurrent allocation, symlinked sibling-script resolution, non-default locale).

**Hot-fixes included:**
- `checkbox-flip-all.sh` now preserves CRLF on write (was silently downgrading to LF, contradicting the FEAT-019 rule in `finalizing-workflow/SKILL.md`).
- `create-pr.sh` disables the `patsub_replacement` shopt at entry so literal `&` in summaries survives body substitution on bash 5.2+ (Ubuntu CI default).

See [CHANGELOG.md](plugins/lwndev-sdlc/CHANGELOG.md) for the full entry.

## Version

- `plugins/lwndev-sdlc/.claude-plugin/plugin.json`: 1.13.0 → 1.14.0
- `.claude-plugin/marketplace.json`: 1.13.0 → 1.14.0
- `plugins/lwndev-sdlc/README.md`: version line updated

## Test plan

- [x] `shellcheck -S warning plugins/lwndev-sdlc/scripts/*.sh` — clean on all 10 scripts
- [x] `bats plugins/lwndev-sdlc/scripts/tests/*.bats` — 96/96 pass (95 from FEAT-020 + 1 new regression guard)
- [x] `npm test` — 982/982 pass on bash 3.2 (local) and bash 5.2 (CI green on #194)
- [x] `npm run validate` — 13/13 skills validated
- [x] Version values consistent across `plugin.json`, `marketplace.json`, and `README.md`

## Release ceremony

After merge, re-invoke `/releasing-plugins` to run Phase 2 (create + push the `lwndev-sdlc@1.14.0` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)