### PR TITLE
release(lwndev-sdlc): v1.15.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.15.0"
+      "version": "1.15.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.15.1] - 2026-04-21
+
+### Documentation
+
+- **orchestrating-workflows:** Output token optimization pilot (CHORE-034). Adds an `## Output Style` section to `orchestrating-workflows/SKILL.md` pinning lite-narration rules, a load-bearing carve-out list (error messages, security warnings, interactive prompts, findings display, FR-14 echoes, `[info]`/`[warn]`/`[model]` tagged logs, user-visible state transitions), and a three-shape fork-to-orchestrator return contract: `done | artifact=<path> | <note>` for success, `failed | <reason>` for failure, and the pre-existing `Found **N errors**, **N warnings**, **N info**` summary for `reviewing-requirements` forks. Every fork-invocation spec in `references/step-execution-details.md` now points subagents at the contract. Documentation-only — no behavioral changes, no new parsers. Captures baseline/post-change static measurements and a Learnings subsection so the same pattern can be replicated across the remaining twelve skills; rollout tracked in [#200](https://github.com/lwndev/lwndev-marketplace/issues/200).
+
+[1.15.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.15.0...lwndev-sdlc@1.15.1
+
 ## [1.15.0] - 2026-04-21
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.15.0 | **Released:** 2026-04-21
+**Version:** 1.15.1 | **Released:** 2026-04-21
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release of `lwndev-sdlc` — pure documentation + tooling-convention update; no behavioral changes.

- **orchestrating-workflows** gains an `## Output Style` section (CHORE-034) that pins lite-narration rules, enumerates load-bearing carve-outs (error messages, security warnings, interactive prompts, findings display, FR-14 echoes, `[info]`/`[warn]`/`[model]` tagged logs, user-visible state transitions), and formalizes a three-shape fork-to-orchestrator return contract: `done | artifact=... | note`, `failed | reason`, plus the retained `Found **N errors**, **N warnings**, **N info**` summary for `reviewing-requirements` forks.
- **references/step-execution-details.md** gets a one-line contract-shape pointer at every fork-invocation spec so subagents discover the contract from the local reference.
- **references/chain-procedures.md** has three transitional sentences tightened (load-bearing procedural content is untouched).
- Closes CHORE-034 ([#198](https://github.com/lwndev/lwndev-marketplace/issues/198)); rollout of the same pattern to the remaining twelve skills tracked in [#200](https://github.com/lwndev/lwndev-marketplace/issues/200).

Full measurement tables and pilot learnings are in [CHORE-034's chore doc](https://github.com/lwndev/lwndev-marketplace/blob/main/requirements/chores/CHORE-034-output-token-optimization-pilot.md).

## Test plan

- [x] `npm run validate` passes (13/13 plugin checks)
- [x] `npm test` passes (1075/1075 — new `qa-CHORE-034.spec.ts` suite adds 29 documentation-contract regression assertions)
- [x] Version values consistent: `plugin.json` = `marketplace.json` = `README.md` = `1.15.1`
- [x] Changelog entry is user-facing rather than a raw commit-log dump
- [x] No runtime/behavioral changes — contract is documentation-only until a parser is added in the rollout chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)