### PR TITLE
release(lwndev-sdlc): v1.15.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.15.1"
+      "version": "1.15.2"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.15.2] - 2026-04-21
+
+### Documentation
+
+- **orchestrating-workflows:** Input token optimization pilot (CHORE-035). Sister effort to CHORE-034's output-token pass, this chore targets the per-invocation instruction surface loaded on every orchestrator invocation and every forked sub-agent spawn. `orchestrating-workflows/SKILL.md` prose compressed to lite style, two heavy numbered recipes relocated into new reference files (`references/forked-steps.md`, `references/reviewing-requirements-flow.md`) with single-sentence inline pointers preserved, and the three per-chain step-sequence tables (Feature / Chore / Bug) collapsed into one parameterized table plus a per-chain deltas note. Net effect on SKILL.md: −212 lines / −2240 words / −16622 chars (−43% char reduction, ~4155 input tokens saved per load). Behaviour-neutral refactor — all CHORE-034 load-bearing carve-outs (error messages, security warnings, interactive prompts, findings display, FR-14 Unicode-arrow echoes, `[info]`/`[warn]`/`[model]` tagged logs, user-visible state transitions) and the fork-to-orchestrator return contract are preserved verbatim; no skill frontmatter changes; no new or renamed skills; no state-file schema changes (step-index numbering invariant across the relocation). `scripts/__tests__/qa-CHORE-035.spec.ts` adds 47 regression guards covering inline-pointer integrity, consolidated-table row preservation, state-file step-index invariance, and CHORE-034 carve-out / fork-return-contract preservation. Rollout to the remaining twelve skills tracked in [#203](https://github.com/lwndev/lwndev-marketplace/issues/203).
+
+[1.15.2]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.15.1...lwndev-sdlc@1.15.2
+
 ## [1.15.1] - 2026-04-21
 
 ### Documentation

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.15.1 | **Released:** 2026-04-21
+**Version:** 1.15.2 | **Released:** 2026-04-21
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release for the `lwndev-sdlc` plugin rolling up the CHORE-035 input-token optimization pilot.

- `orchestrating-workflows/SKILL.md` compressed to lite-narration style; heavy numbered recipes relocated to `references/forked-steps.md` and `references/reviewing-requirements-flow.md`; three per-chain step-sequence tables collapsed into one parameterized table plus a per-chain deltas note. Net effect on SKILL.md: −43% chars (~4155 input tokens saved per load).
- Behaviour-neutral refactor — all CHORE-034 load-bearing carve-outs and the fork-to-orchestrator return contract are preserved verbatim; state-file schema and step-index numbering unchanged.
- 47-case adversarial regression suite added (`scripts/__tests__/qa-CHORE-035.spec.ts`) guarding inline-pointer integrity, consolidated-table row preservation, state-file step-index invariance, and CHORE-034 carve-out preservation.

Rollout to the remaining twelve skills tracked in #203.

## Test plan

- [x] `npm test` — 1122 / 1122 pass (47 new CHORE-035 cases, zero regressions)
- [x] `npm run validate` — all 13 skills pass 19/19 checks
- [x] Version consistent across `plugins/lwndev-sdlc/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugins/lwndev-sdlc/README.md` (all at `1.15.2`)
- [x] QA verdict for CHORE-035: PASS (`qa/test-results/QA-results-CHORE-035.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)