### PR TITLE
fix(BUG-012): pin qa-fixture vitest to patched range (CVE-2025-24964)

### DIFF
--- a/qa/test-plans/QA-plan-BUG-012.md
+++ b/qa/test-plans/QA-plan-BUG-012.md
@@ -1,0 +1,48 @@
+---
+id: BUG-012
+version: 2
+timestamp: 2026-04-22T21:03:00Z
+persona: qa
+---
+
+## User Summary
+
+Resolve Dependabot alert #22 (critical vitest RCE; CVE-2025-24964 / GHSA-9crc-q9x8-hgqq, CVSS 9.7) by pinning the QA integration test fixture's `vitest` devDependency to a non-vulnerable range. The fixture's `"vitest": "*"` declaration in `scripts/__tests__/fixtures/qa-fixture/package.json` currently matches the vulnerable `<= 0.0.125` window even though no vitest is ever actually installed inside the fixture (no local `node_modules`) and the integration test invokes the root-level `vitest@^3.2.3` binary explicitly. The fix changes the fixture's declared range to `^3.2.3` to mirror the root `package.json`, keeping the devDep present as the primary `pkg_has_dep` detection signal for `capability-discovery.sh`. The integration test continues to pass, and the Dependabot alert auto-closes once the vulnerable range no longer matches.
+
+## Capability Report
+
+- Mode: test-framework
+- Framework: vitest
+- Package manager: npm
+- Test command: npm test
+- Language: typescript
+
+## Scenarios (by dimension)
+
+### Inputs
+- [P0] `capability-discovery.sh` on the updated fixture still resolves `framework: "vitest"` via the `pkg_has_dep "vitest"` path (primary detection signal must keep working after the pin) | mode: test-framework | expected: integration test asserts `report.framework === "vitest"` against the updated fixture
+- [P1] Wildcard regression guard: a grep of `scripts/__tests__/fixtures/qa-fixture/package.json` for a bare `"*"` range on `vitest` returns no match | mode: test-framework | expected: lint-style assertion — `grep '"vitest":\s*"\*"'` in the fixture exits non-zero
+- [P1] Declared range excludes the vulnerable windows the advisory lists (`<= 0.0.125`, `>= 1.0.0 < 1.6.1`, `>= 2.0.0 < 2.1.9`, `>= 3.0.0 < 3.0.5`) | mode: test-framework | expected: assertion that the pinned semver range, intersected with each vulnerable window via `semver.intersects(range, window)`, returns false for every window
+- [P2] Malformed fixture `package.json` (deliberately trailing comma / unterminated string) does not regress — `capability-discovery.sh` exits gracefully and the integration test still produces a capability report | mode: exploratory | expected: manual test — break the fixture, rerun, confirm script does not crash the harness
+
+### State transitions
+- [P2] Idempotency: re-running the bug fix (committing an identical change to the fixture a second time) is a no-op — no churn, no additional Dependabot noise | mode: exploratory | expected: second `git diff` shows empty; Dependabot alert status unchanged
+
+### Environment
+- [P1] Integration test works from a fresh clone without a pre-existing `node_modules` inside the fixture (the fixture must still not install vitest locally; root `node_modules/.bin/vitest` remains the only install) | mode: exploratory | expected: `rm -rf node_modules && npm ci && npm test -- --testPathPatterns=qa-integration` passes
+- [P1] Offline / no-network rerun of `npm test` after `npm ci`: integration test resolves root vitest binary without reaching npm registry for the fixture | mode: exploratory | expected: disable network, rerun `npm test -- --testPathPatterns=qa-integration`, confirm pass
+- [P2] Dependabot re-scan on merge: alert #22 auto-closes within one scan cycle (usually < 24h) with reason "fixed" | mode: exploratory | expected: inspect `gh api repos/lwndev/lwndev-marketplace/dependabot/alerts/22` post-merge and confirm `state: fixed` or `state: dismissed`
+
+### Dependency failure
+- [P0] `npm test` at repo root still passes `qa-integration.test.ts` end-to-end (capability discovery + fixture vitest run using the root binary) with the fixture's declared range changed | mode: test-framework | expected: `npm test -- --testPathPatterns=qa-integration` exit code 0
+- [P1] `^3.2.3` satisfies future patch releases of vitest 3.x (standard semver behavior) and continues to lie outside every vulnerable window declared by the advisory, even if minor bumps ship | mode: test-framework | expected: semver assertion — for each candidate future version (`3.2.3`, `3.2.99`, `3.99.0`), `semver.satisfies(candidate, "^3.2.3")` is true AND `semver.intersects("^3.2.3", vulnerable-window)` is false
+- [P2] Transitive `vite` pulled by vitest has no currently-open advisories overlapping with the resolved install tree | mode: exploratory | expected: `npm audit --audit-level=high` in the fixture directory (after optional `npm install`) reports no criticals; advisory surface visible in Dependabot UI is unchanged
+- [P2] Root `package.json` vitest range drifts ahead of fixture: fixture and root should stay in lock-step per Notes, but the fix does not introduce an automated enforcement mechanism | mode: exploratory | expected: follow-up guardrail candidate — manual inspection, not a failing test today
+
+### Cross-cutting (a11y, i18n, concurrency, permissions)
+- [P2] Contributor affordance: a comment or README note on the fixture's `package.json` makes it discoverable that the devDep range is a detection signal and must stay present — relevant since the bug doc cites "cleanup deletion" as a realistic future regression mode | mode: exploratory | expected: reviewer checks the fix PR for an inline rationale; absence is flagged as an info-level observation during code review
+
+## Non-applicable dimensions
+
+- state-transitions: This change is a one-line static config edit to a test fixture's `package.json`. There is no state machine, no user interaction flow, no cancellation path, no concurrent-write surface. A single P2 idempotency scenario is included above for completeness; every other state-transition probe (cancel mid-flow, double-click, stale tabs, concurrent modification) is meaningless for a declarative config edit.
+- cross-cutting (a11y, i18n, concurrency, permissions, beyond the P2 reviewer affordance above): The fixture is consumed only by the integration test suite; it ships no UI, no user-facing text, no locale-sensitive behavior, no permission model, and no concurrent access pattern. Accessibility, internationalization, concurrency semantics, and permission-related probes are structurally inapplicable.

--- a/qa/test-results/QA-results-BUG-012.md
+++ b/qa/test-results/QA-results-BUG-012.md
@@ -1,0 +1,71 @@
+---
+id: BUG-012
+version: 2
+timestamp: 2026-04-22T21:19:00Z
+verdict: PASS
+persona: qa
+---
+
+## Summary
+
+All five P0/P1 test-framework scenarios from `qa/test-plans/QA-plan-BUG-012.md` passed against the `fix/BUG-012-vitest-rce-qa-fixture` branch. The fixture `vitest` devDep is pinned to `^3.2.3` (from `"*"`); capability-discovery still detects the fixture as `vitest`, the declared range excludes every advisory vulnerable window, and the full suite (1328 tests) is green.
+
+## Capability Report
+
+- Mode: test-framework
+- Framework: vitest
+- Package manager: npm
+- Test command: npm test
+- Language: typescript
+
+## Execution Results
+
+- Total: 5
+- Passed: 5
+- Failed: 0
+- Errored: 0
+- Exit code: 0
+- Duration: 0.362s
+- Test files: [scripts/__tests__/qa-inputs-BUG-012.test.ts, scripts/__tests__/qa-dependency-failure-BUG-012.test.ts]
+
+Scoped command: `npx vitest run scripts/__tests__/qa-inputs-BUG-012.test.ts scripts/__tests__/qa-dependency-failure-BUG-012.test.ts`.
+
+Full-suite control run: `npm test` → `Test Files 39 passed (39), Tests 1328 passed (1328), Duration 44.21s`. No regressions elsewhere in the suite from the QA test additions.
+
+## Scenarios Run
+
+| ID | Dimension | Priority | Result | Test file |
+|----|-----------|----------|--------|-----------|
+| INP-1 | Inputs | P0 | PASS | scripts/__tests__/qa-inputs-BUG-012.test.ts (capability-discovery resolves the updated fixture as framework "vitest") |
+| INP-2 | Inputs | P1 | PASS | scripts/__tests__/qa-inputs-BUG-012.test.ts (wildcard regression guard — no bare "*" vitest range) |
+| INP-3 | Inputs | P1 | PASS | scripts/__tests__/qa-inputs-BUG-012.test.ts (declared range does not intersect any advisory vulnerable window) |
+| DEP-1 | Dependency failure | P0 | PASS | scripts/__tests__/qa-dependency-failure-BUG-012.test.ts (qa-integration prerequisites hold — file, root vitest bin, fixture detection) |
+| DEP-2 | Dependency failure | P1 | PASS | scripts/__tests__/qa-dependency-failure-BUG-012.test.ts (declared range accepts future vitest 3.x releases and excludes every vulnerable window) |
+
+Exploratory/P2 scenarios from the plan not exercised in test-framework mode (intentional — the plan marked them `mode: exploratory`): INP malformed-package-json probe, idempotency rerun, fresh-clone install, offline install rerun, Dependabot re-scan, transitive-`vite` advisory scan, fixture/root lock-step drift guardrail, reviewer-affordance inline comment. These remain exploratory per plan and are not graded in this run.
+
+## Findings
+
+No failing tests. No verdict-blocking findings.
+
+Observational notes (not failures):
+- **INP-1 / DEP-1 semantic overlap**: both scenarios exercise the same `capability-discovery.sh` invocation against the real fixture. This was a deliberate design choice to avoid spawning a nested vitest-in-vitest subprocess for the end-to-end DEP-1 check; the static prerequisites (integration test file, root vitest bin, imports) plus the dynamic capability-discovery call together are the load-bearing signal that `qa-integration.test.ts` would still pass. The full-suite run above independently confirms that by actually running `qa-integration.test.ts` to completion.
+- **DEP-2 future-version assertion**: the semver-intersect check is an invariant probe, not a runtime probe. It guards against a future edit that tightens the range into a vulnerable window (e.g., re-introducing `<=0.0.125` via a botched pin). If vitest ships a new advisory later, this test will not catch it — a Dependabot rescan would. That limitation is captured in the plan's Dependency-failure P2 exploratory item and is not in scope for this run.
+
+## Reconciliation Delta
+
+### Coverage beyond requirements
+- Scenario DEP-2 (future-version semver invariant: `^3.2.3` accepts `3.2.3 / 3.2.99 / 3.3.0 / 3.99.0` AND excludes every vulnerable window) is not a literal acceptance-criterion in BUG-012 — the ACs only require a non-vulnerable pin today. DEP-2 is adversarial reinforcement against a future narrow-range regression.
+- Scenario INP-2 (wildcard regression guard) likewise goes beyond the literal AC-1 language — AC-1 requires pinning; INP-2 additionally locks out the `"*"` form from ever reappearing via a static source-level assertion.
+
+### Coverage gaps
+- AC-3 ("Dependabot alert #22 auto-closes on the resulting merge, or is manually dismissable as resolved") has no executable test in this run. Dependabot alert state is an external-to-repo event that only resolves post-merge during Dependabot's next scan. The plan explicitly marked this as `mode: exploratory` (Environment P2) and it is correctly deferred. It should be manually verified post-merge by checking `gh api repos/lwndev/lwndev-marketplace/dependabot/alerts/22` for `state: fixed`.
+- The plan's P1 exploratory scenarios (fresh-clone install, offline rerun after `npm ci`) are not exercised — they are environmental probes that require reshaping the working tree, outside the scope of a test-framework QA run. No new coverage gap against BUG-012 requirements; they are adversarial rigor beyond the ACs.
+
+### Summary
+- coverage-surplus: 2
+- coverage-gap: 1
+
+## Exploratory Mode
+
+Not applicable — this run was test-framework mode.

--- a/requirements/bugs/BUG-012-vitest-rce-in-qa.md
+++ b/requirements/bugs/BUG-012-vitest-rce-in-qa.md
@@ -1,0 +1,66 @@
+# Bug: vitest RCE in QA Fixture
+
+## Bug ID
+
+`BUG-012`
+
+## GitHub Issue
+
+[#216](https://github.com/lwndev/lwndev-marketplace/issues/216)
+
+## Category
+
+`security`
+
+## Severity
+
+`critical`
+
+## Description
+
+Dependabot alert #22 flags a critical vitest vulnerability (CVSS 9.7, CVE-2025-24964 / GHSA-9crc-q9x8-hgqq) sourced from the QA integration test fixture. The fixture's `package.json` declares `"vitest": "*"`, which satisfies the vulnerable range `<= 0.0.125` and causes the repository to appear exposed to Cross-Site WebSocket Hijacking leading to arbitrary code execution when the Vitest UI/API is running.
+
+## Steps to Reproduce
+
+1. Visit the repository's Dependabot alerts page (`/security/dependabot/22`).
+2. Observe the open alert for `vitest` originating from `scripts/__tests__/fixtures/qa-fixture/package.json`.
+3. Inspect `scripts/__tests__/fixtures/qa-fixture/package.json` and note `"vitest": "*"`.
+
+## Expected Behavior
+
+- The fixture's `vitest` devDependency declares a non-vulnerable range.
+- Dependabot alert #22 auto-closes (or can be dismissed as resolved).
+- `scripts/__tests__/qa-integration.test.ts` continues to pass.
+
+## Actual Behavior
+
+- The unbounded `*` range matches the vulnerable `<= 0.0.125` window (along with several other vulnerable ranges).
+- Dependabot flags the repository as critical severity even though no version of vitest is installed inside the fixture and the integration test invokes the root-level `node_modules/.bin/vitest@^3.2.3` binary explicitly.
+
+## Root Cause(s)
+
+1. `scripts/__tests__/fixtures/qa-fixture/package.json:8` declares `"vitest": "*"`. The fixture is shipped only to exercise `capability-discovery.sh`'s framework-detection path (`plugins/lwndev-sdlc/skills/executing-qa/scripts/capability-discovery.sh:101` checks `pkg_has_dep "vitest"`; line 102 additionally accepts `vitest.config.ts` / `.js` / `.mjs` as a secondary signal, and the fixture ships `vitest.config.ts`), so the declared range is intentionally kept as a package-json detection signal — not a resolvable install target — but the wildcard still satisfies the vulnerable ranges Dependabot matches against.
+
+## Affected Files
+
+- `scripts/__tests__/fixtures/qa-fixture/package.json`
+
+## Acceptance Criteria
+
+- [x] Fixture `vitest` devDependency remains declared in `scripts/__tests__/fixtures/qa-fixture/package.json` and is pinned to a non-vulnerable range matching the advisory's safe windows (`>=1.6.1 <2.0.0 || >=2.1.9 <3.0.0 || >=3.0.5`) — preferably `^3.2.3` to mirror the root `package.json`. The devDep is not deleted; it must stay present as the primary `pkg_has_dep`-based detection signal, even though `vitest.config.ts` would redundantly satisfy detection (RC-1)
+- [x] `scripts/__tests__/qa-integration.test.ts` continues to pass — `capability-discovery` still resolves the fixture as framework `vitest`, and the end-to-end flow still produces the expected non-zero-exit failure report (RC-1)
+- [x] Dependabot alert #22 auto-closes on the resulting merge, or is manually dismissable as resolved because the declared range no longer matches any vulnerable window (RC-1)
+
+## Completion
+
+**Status:** `Completed`
+
+**Completed:** 2026-04-22
+
+**Pull Request:** [#N](https://github.com/lwndev/lwndev-marketplace/pull/N)
+
+## Notes
+
+- Exposure in this repository is low: the fixture has no `node_modules` of its own, and `scripts/__tests__/qa-integration.test.ts:49` explicitly invokes `<repo>/node_modules/.bin/vitest` (root `vitest@^3.2.3`, already patched). The declared range is a detection signal for `capability-discovery.sh`, not an install target.
+- No production / plugin consumer code depends on vitest; the fixture is consumed only by the integration suite and is not shipped with any published plugin.
+- Root `package.json` already pins `vitest@^3.2.3` — aligning the fixture with the same range keeps future version bumps in lock-step.

--- a/requirements/bugs/BUG-012-vitest-rce-in-qa.md
+++ b/requirements/bugs/BUG-012-vitest-rce-in-qa.md
@@ -57,7 +57,7 @@ Dependabot alert #22 flags a critical vitest vulnerability (CVSS 9.7, CVE-2025-2
 
 **Completed:** 2026-04-22
 
-**Pull Request:** [#N](https://github.com/lwndev/lwndev-marketplace/pull/N)
+**Pull Request:** [#218](https://github.com/lwndev/lwndev-marketplace/pull/218)
 
 ## Notes
 

--- a/scripts/__tests__/fixtures/qa-fixture/package.json
+++ b/scripts/__tests__/fixtures/qa-fixture/package.json
@@ -5,6 +5,6 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "*"
+    "vitest": "^3.2.3"
   }
 }

--- a/scripts/__tests__/qa-dependency-failure-BUG-012.test.ts
+++ b/scripts/__tests__/qa-dependency-failure-BUG-012.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import semver from 'semver';
+
+const ROOT = join(__dirname, '..', '..');
+const INTEGRATION_TEST = join(ROOT, 'scripts/__tests__/qa-integration.test.ts');
+const ROOT_VITEST_BIN = join(ROOT, 'node_modules/.bin/vitest');
+const FIXTURE_PACKAGE_JSON = join(ROOT, 'scripts/__tests__/fixtures/qa-fixture/package.json');
+const CAPABILITY_DISCOVERY_SH = join(
+  ROOT,
+  'plugins/lwndev-sdlc/skills/executing-qa/scripts/capability-discovery.sh'
+);
+const QA_FIXTURE_DIR = join(ROOT, 'scripts/__tests__/fixtures/qa-fixture');
+
+const VULNERABLE_WINDOWS = ['<=0.0.125', '>=1.0.0 <1.6.1', '>=2.0.0 <2.1.9', '>=3.0.0 <3.0.5'];
+
+// Future-version candidates covering minor and patch drift within the pinned
+// major; each must be accepted by the declared range AND fall outside every
+// vulnerable window.
+const FUTURE_CANDIDATES = ['3.2.3', '3.2.99', '3.3.0', '3.99.0'];
+
+describe('BUG-012 — dependency-failure dimension', () => {
+  it('[P0] qa-integration test prerequisites still hold (file, root vitest bin, fixture detection)', () => {
+    // Static prerequisites: the integration test file and the root-level vitest
+    // binary it shells into must both exist. Without either one, scenario 4
+    // would have collapsed silently.
+    expect(existsSync(INTEGRATION_TEST)).toBe(true);
+    expect(existsSync(ROOT_VITEST_BIN)).toBe(true);
+
+    // Source-level sanity: the integration test references the root vitest
+    // path and the updated fixture. A rename of either would invalidate the
+    // end-to-end assertion chain.
+    const src = readFileSync(INTEGRATION_TEST, 'utf8');
+    expect(src).toContain('node_modules/.bin/vitest');
+    expect(src).toContain('fixtures/qa-fixture');
+
+    // Dynamic prerequisite: the same capability-discovery invocation the
+    // integration test relies on still resolves the fixture as vitest after
+    // the devDep pin. This is the load-bearing end-to-end signal short of
+    // spawning nested vitest-in-vitest.
+    const raw = execFileSync('bash', [CAPABILITY_DISCOVERY_SH, QA_FIXTURE_DIR, 'BUG-012'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const report = JSON.parse(raw) as { framework: string; testCommand: string };
+    expect(report.framework).toBe('vitest');
+    expect(report.testCommand).toBe('npm test');
+  });
+
+  it('[P1] declared range accepts future vitest 3.x releases and excludes every vulnerable window', () => {
+    const manifest = JSON.parse(readFileSync(FIXTURE_PACKAGE_JSON, 'utf8')) as {
+      devDependencies?: { vitest?: string };
+    };
+    const declaredRange = manifest.devDependencies?.vitest;
+    expect(declaredRange).toBeDefined();
+
+    for (const candidate of FUTURE_CANDIDATES) {
+      expect(
+        semver.satisfies(candidate, declaredRange!),
+        `declared range "${declaredRange}" must accept future candidate ${candidate}`
+      ).toBe(true);
+    }
+
+    for (const window of VULNERABLE_WINDOWS) {
+      expect(
+        semver.intersects(declaredRange!, window),
+        `declared range "${declaredRange}" must NOT intersect vulnerable window "${window}"`
+      ).toBe(false);
+    }
+  });
+});

--- a/scripts/__tests__/qa-inputs-BUG-012.test.ts
+++ b/scripts/__tests__/qa-inputs-BUG-012.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import semver from 'semver';
+
+const ROOT = join(__dirname, '..', '..');
+const FIXTURE_PACKAGE_JSON = join(ROOT, 'scripts/__tests__/fixtures/qa-fixture/package.json');
+const CAPABILITY_DISCOVERY_SH = join(
+  ROOT,
+  'plugins/lwndev-sdlc/skills/executing-qa/scripts/capability-discovery.sh'
+);
+const QA_FIXTURE_DIR = join(ROOT, 'scripts/__tests__/fixtures/qa-fixture');
+
+// GHSA-9crc-q9x8-hgqq / CVE-2025-24964 — advisory's vulnerable ranges
+// transcribed as semver-compatible range strings (coerced to lowercase-only
+// operator forms that node-semver accepts).
+const VULNERABLE_WINDOWS = ['<=0.0.125', '>=1.0.0 <1.6.1', '>=2.0.0 <2.1.9', '>=3.0.0 <3.0.5'];
+
+describe('BUG-012 — inputs dimension', () => {
+  it('[P0] capability-discovery resolves the updated fixture as framework "vitest"', () => {
+    const raw = execFileSync('bash', [CAPABILITY_DISCOVERY_SH, QA_FIXTURE_DIR, 'BUG-012'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const report = JSON.parse(raw) as {
+      framework: string;
+      mode: string;
+      testCommand: string;
+    };
+    // Primary detection signal must keep working after the pin.
+    expect(report.framework).toBe('vitest');
+    expect(report.mode).toBe('test-framework');
+  });
+
+  it('[P1] wildcard regression guard — fixture package.json has no bare "*" vitest range', () => {
+    const contents = readFileSync(FIXTURE_PACKAGE_JSON, 'utf8');
+    // Accept any whitespace between the key and the value; reject only the
+    // unbounded "*" form. This catches an accidental revert.
+    expect(contents).not.toMatch(/"vitest"\s*:\s*"\*"/);
+  });
+
+  it('[P1] declared vitest range does not intersect any advisory vulnerable window', () => {
+    const manifest = JSON.parse(readFileSync(FIXTURE_PACKAGE_JSON, 'utf8')) as {
+      devDependencies?: { vitest?: string };
+    };
+    const declaredRange = manifest.devDependencies?.vitest;
+    expect(declaredRange).toBeDefined();
+    expect(declaredRange).not.toBe('*');
+
+    // Sanity: the pin keeps the devDep present (required by AC-1 to preserve
+    // capability-discovery's pkg_has_dep detection path).
+    expect(existsSync(FIXTURE_PACKAGE_JSON)).toBe(true);
+
+    for (const window of VULNERABLE_WINDOWS) {
+      expect(
+        semver.intersects(declaredRange!, window),
+        `declared range "${declaredRange}" must NOT intersect vulnerable window "${window}"`
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

fix BUG-012: pin qa-fixture vitest to patched range (CVE-2025-24964)

Closes #216

## Test plan

- [ ] Tests updated or added as appropriate
- [ ] `npm run validate` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)