### PR TITLE
release(lwndev-sdlc): v1.21.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.21.0"
+      "version": "1.21.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.21.1] - 2026-04-25
+
+### Bug Fixes
+
+- **BUG-013:** phase-completion skills no longer declare success without running the repo's lint/format/test gates ([#212](https://github.com/lwndev/lwndev-marketplace/issues/212)). Adds shared `plugins/lwndev-sdlc/scripts/verify-build-health.sh` that detects available `package.json` scripts (`lint`, `format:check`, `test`, `build`; `validate` opt-in via `--include-validate`), runs each that exists, and halts on the first non-zero exit. Wired into all six affected skills with the documented interactive vs non-interactive split: `executing-chores` Step 7, `executing-bug-fixes` Step 9, `implementing-plan-phases` (lint/format added to `verify-phase-deliverables.sh`'s JSON contract), `executing-qa` (new Step 5.5, `--no-interactive`), `finalizing-workflow` `preflight-checks.sh` (`--no-interactive`), and `releasing-plugins` (new Step 8 between changelog and push). The auto-fix branch (`lint:fix` / `format`) is reachable only at the four interactive sites; QA and finalize fail-fast. 21-test bats suite plus 7-scenario vitest adversarial suite at `scripts/__tests__/qa-bug-013.test.ts`. Closes the gap that was leaking prettier/eslint errors to release branches and `main` (CI runs 24781710973, 24781373957, 24781373952). Merged via PR [#237](https://github.com/lwndev/lwndev-marketplace/pull/237).
+- **security:** bump `postcss` from 8.5.8 to 8.5.10 to clear `npm audit` advisory [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (XSS via unescaped `</style>` in CSS Stringify output). Transitive devDependency only.
+
+[1.21.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.21.0...lwndev-sdlc@1.21.1
+
 ## [1.21.0] - 2026-04-25
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.21.0 | **Released:** 2026-04-25
+**Version:** 1.21.1 | **Released:** 2026-04-25
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release wrapping up BUG-013 plus a transitive `postcss` audit bump.

- **BUG-013** ([#212](https://github.com/lwndev/lwndev-marketplace/issues/212)) — phase-completion skills now run the repo's lint/format/test commands before declaring success. New shared `plugins/lwndev-sdlc/scripts/verify-build-health.sh` is wired into all six affected skills (`executing-chores`, `executing-bug-fixes`, `implementing-plan-phases`, `executing-qa`, `finalizing-workflow`, `releasing-plugins`) with the documented interactive / non-interactive split. 21-test bats fixture + 7-scenario vitest adversarial suite. Closes the gap that was leaking prettier/eslint errors to release branches and `main`.
- **security** — `postcss` 8.5.8 → 8.5.10 to clear `npm audit` advisory [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93). Transitive devDependency only.

See `plugins/lwndev-sdlc/CHANGELOG.md` for the full entry.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm test\` — 1466/1466 passing
- [x] \`bash plugins/lwndev-sdlc/scripts/verify-build-health.sh --no-interactive\` — exit 0
- [x] \`bats plugins/lwndev-sdlc/scripts/tests/verify-build-health.bats\` — 21/21 passing
- [ ] CI green on this release branch
- [ ] After merge: \`/releasing-plugins\` Phase 2 to tag and push