### PR TITLE
release(lwndev-sdlc): v1.23.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.23.0"
+      "version": "1.23.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.23.1] - 2026-04-28
+
+### Bug Fixes
+
+- **BUG-014 (security):** add a four-hook confirmation-gate defense layer that closes the gap where state transitions could advance without a real user approval ([#247](https://github.com/lwndev/lwndev-marketplace/pull/247)). Hook A (`record-approval.sh`, UserPromptSubmit) writes approval markers; Hook B (`guard-state-transitions.sh`) blocks `resume`, `clear-gate`, and destructive Bash without a fresh marker, using a `pausedAt` timestamp anchor newly added to `workflow-state.sh cmd_pause`; Hook C (`guard-agent-prompts.sh`) enforces carve-outs and confirmation-owning-skill checks on agent prompts; Hook D ships a managed-settings template for destructive-Bash defense-in-depth at the harness level. Hooks A/B/C are wired in `plugins/lwndev-sdlc/hooks/hooks.json`. The approval-marker grammar is documented in `orchestrating-workflows/SKILL.md`, and an end-to-end auto-mode bats regression covers the full flow (the suite also fixed a BSD `date` UTC handling bug discovered while writing it).
+- **BUG-014 (portability):** make the marker mtime check work on Linux ([#248](https://github.com/lwndev/lwndev-marketplace/pull/248)). The mtime epoch derivation relied on BSD `stat` flags; the fix resolves the platform-specific `stat` arguments so the gate behaves identically on Linux CI and macOS dev machines. Covered by a new test for `marker_mtime_epoch` stat ordering.
+
+### Tests
+
+- Bump global vitest `testTimeout` to 15s to stabilize flaky `execSync`-based tests on slower CI runners.
+- New adversarial vitest suite for BUG-014 covering the hook chain and marker grammar.
+
+[1.23.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.23.0...lwndev-sdlc@1.23.1
+
 ## [1.23.0] - 2026-04-26
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.23.0 | **Released:** 2026-04-26
+**Version:** 1.23.1 | **Released:** 2026-04-28
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Summary

Patch release for `lwndev-sdlc@1.23.1` covering BUG-014 (confirmation-gate hooks + Linux portability) plus minor test-suite stabilization.

## Changes

### Bug Fixes
- **BUG-014 (security):** four-hook confirmation-gate defense layer (Hooks A/B/C/D) closing the gap where state transitions could advance without a real user approval (#247). Wires Hook A `record-approval.sh`, Hook B `guard-state-transitions.sh`, Hook C `guard-agent-prompts.sh` in `hooks.json`; Hook D ships a managed-settings template for harness-level destructive-Bash defense-in-depth. Adds `pausedAt` timestamp anchor to `workflow-state.sh cmd_pause`. End-to-end auto-mode bats regression covers the full flow (also fixes a BSD `date` UTC handling bug surfaced while writing it).
- **BUG-014 (portability):** make the marker mtime check work on Linux (#248). Resolves platform-specific `stat` arguments so the gate behaves identically on Linux CI and macOS.

### Tests
- Bump global vitest `testTimeout` to 15s to stabilize flaky `execSync`-based tests on slower CI runners.
- New adversarial vitest suite for BUG-014 covering the hook chain and marker grammar.

## Verification
- [x] Versions consistent across `plugin.json`, `marketplace.json`, `README.md` (1.23.0 → 1.23.1)
- [x] Changelog refined (combined hooks + portability commits into coherent user-facing entries)
- [x] Build-health gate passed (`verify-build-health.sh`): lint, format:check, build, 1494 tests across 48 files all green

## Test plan
- [ ] CI checks pass on this PR
- [ ] After merge, run Phase 2 tagging via `/releasing-plugins` to push the `lwndev-sdlc@1.23.1` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)