### PR TITLE
fix(BUG-015): close findings-decision Edit gate, finalizing-workflow general-purpose fork bypass, and stale-marker race (BUG-015 RC-1, RC-2, RC-3)

### DIFF
--- a/plugins/lwndev-sdlc/hooks/hooks.json
+++ b/plugins/lwndev-sdlc/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "BUG-014 confirmation-gate hooks. Hook A (UserPromptSubmit) writes approval markers from canonical user input shapes. Hook B (PreToolUse Bash) denies workflow-state.sh resume/clear-gate and destructive Bash without a fresh marker. Hook C (PreToolUse Task/Agent) denies carve-out prompts and forks of confirmation-owning skills without a marker.",
+  "description": "BUG-014 + BUG-015 confirmation-gate hooks. Hook A (UserPromptSubmit) writes approval markers from canonical user input shapes. Hook B (PreToolUse Bash) denies workflow-state.sh resume/clear-gate and destructive Bash without a fresh marker. Hook C (PreToolUse Task/Agent) denies carve-out prompts and forks of confirmation-owning skills without a marker. BUG-015 Hook (PreToolUse Edit|Write|MultiEdit) denies edits to requirements docs while findings-decision gate is set without a fresh marker.",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -40,6 +40,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/guard-agent-prompts.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/hooks/guard-findings-edits.sh",
             "timeout": 10
           }
         ]

--- a/plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh
+++ b/plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh
@@ -90,9 +90,16 @@ fi
 embedded_norm="$(printf '%s' "${embedded_name##*:}" | tr '[:upper:]' '[:lower:]')"
 
 case "$embedded_norm" in
-  finalizing-workflow)
+  finalizing-workflow*)
     # Embedded SKILL.md is confirmation-owning — that wins regardless of the
     # tool_input.subagent_type label. Closes BUG-015 RC-2 bypass.
+    #
+    # Prefix glob (`finalizing-workflow*`, not exact `finalizing-workflow`)
+    # closes a tamper variant: a fork shaped as
+    # `name: finalizing-workflow-x` + `subagent_type: general-purpose` would
+    # otherwise fall through to the `*` branch and be classified as
+    # general-purpose, skipping AC8. Anything starting with the
+    # confirmation-owning name is treated as the owning skill.
     target_skill="$embedded_name"
     ;;
   *)
@@ -122,7 +129,7 @@ target_skill_norm="$(printf '%s' "${target_skill##*:}" | tr '[:upper:]' '[:lower
 # embedded SKILL.md content for non-gating skills (e.g.
 # reviewing-requirements/SKILL.md:261 "Skip Step 4 unless APIs referenced").
 case "$target_skill_norm" in
-  finalizing-workflow) is_confirmation_owning=1 ;;
+  finalizing-workflow*) is_confirmation_owning=1 ;;
   *) is_confirmation_owning=0 ;;
 esac
 

--- a/plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh
+++ b/plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh
@@ -72,19 +72,43 @@ fi
 # Resolve the target skill once, before either AC7 or AC8 consults it. Real
 # orchestrator forks pass the SKILL.md verbatim (per orchestrating-workflows
 # references/forked-steps.md) and do NOT set subagent_type on every fork —
-# the model decides whether to populate it. The fallback regex therefore has
-# to recognize the YAML frontmatter `name:` key in addition to prose-style
-# `Skill:` / `fork:` / `target:` references kept for defense in depth.
+# the model decides whether to populate it.
+#
+# BUG-015 / RC-2: extract the embedded SKILL.md `name:` frontmatter FIRST. If
+# the embedded name belongs to the confirmation-owning set, it takes precedence
+# over `tool_input.subagent_type` so a fork shaped as
+# `Agent(subagent_type: general-purpose, prompt: <finalizing-workflow SKILL.md>)`
+# is classified by its real payload (finalizing-workflow), not by its label
+# (general-purpose). The previous order-of-precedence (subagent_type first) let
+# this exact shape bypass AC8.
 subagent_type="$(printf '%s' "$payload" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null || true)"
 
-target_skill="$subagent_type"
-if [[ -z "$target_skill" ]]; then
-  if [[ "$prompt_text" =~ (^|[[:space:]])name[[:space:]]*:[[:space:]]*([A-Za-z0-9:_/-]+) ]]; then
-    target_skill="${BASH_REMATCH[2]}"
-  elif [[ "$prompt_text" =~ (^|[[:space:]])(Skill|skill|fork|target)[[:space:]]*[:=][[:space:]]*([A-Za-z0-9:_/-]+) ]]; then
-    target_skill="${BASH_REMATCH[3]}"
-  fi
+embedded_name=""
+if [[ "$prompt_text" =~ (^|[[:space:]])name[[:space:]]*:[[:space:]]*([A-Za-z0-9:_/-]+) ]]; then
+  embedded_name="${BASH_REMATCH[2]}"
 fi
+embedded_norm="$(printf '%s' "${embedded_name##*:}" | tr '[:upper:]' '[:lower:]')"
+
+case "$embedded_norm" in
+  finalizing-workflow)
+    # Embedded SKILL.md is confirmation-owning — that wins regardless of the
+    # tool_input.subagent_type label. Closes BUG-015 RC-2 bypass.
+    target_skill="$embedded_name"
+    ;;
+  *)
+    # Non-confirmation-owning embedded name (or no embedded name at all).
+    # Fall back to subagent_type, then to the prose-style fallback regex chain
+    # for forks that neither label themselves nor embed YAML frontmatter.
+    if [[ -n "$subagent_type" ]]; then
+      target_skill="$subagent_type"
+    else
+      target_skill="$embedded_name"
+      if [[ -z "$target_skill" ]] && [[ "$prompt_text" =~ (^|[[:space:]])(Skill|skill|fork|target)[[:space:]]*[:=][[:space:]]*([A-Za-z0-9:_/-]+) ]]; then
+        target_skill="${BASH_REMATCH[3]}"
+      fi
+    fi
+    ;;
+esac
 
 # Strip plugin prefix and lowercase explicitly. Lowercasing here decouples
 # the case statement below from `nocasematch` shell state — uppercase /

--- a/plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh
+++ b/plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# guard-findings-edits.sh — BUG-015 Hook for findings-decision gate.
+#
+# Wiring: declared in plugins/lwndev-sdlc/hooks/hooks.json against the
+# `PreToolUse` event with matcher `Edit|Write|MultiEdit`. Claude Code invokes
+# this hook before every Edit / Write / MultiEdit tool call with a JSON payload
+# on stdin containing `tool_input.file_path`.
+#
+# Behavior (BUG-015 / RC-1, RC-3):
+#   * If `.sdlc/workflows/.active` is missing OR no workflow has
+#     `gate == findings-decision` set: allow (no gate to guard).
+#   * If `tool_input.file_path` does NOT match the regex
+#       requirements/(features|chores|bugs)/.+\.md
+#     allow (out-of-scope path; no scope creep).
+#   * Otherwise require a fresh `.approval-findings-decision-<active-ID>`
+#     marker with mtime >= state.gateSetAt. Missing marker, missing
+#     `gateSetAt`, or stale marker: deny with the documented systemMessage.
+#     Missing `gateSetAt` is treated as "infinitely old" mirroring BUG-014 / AC9
+#     (pre-fix workflow state files predating BUG-015 cannot be satisfied by
+#     any marker; user must reapprove).
+#
+# Why this hook exists: BUG-014's Hook B only guards the `Bash` tool, leaving
+# `Edit` / `Write` / `MultiEdit` unguarded against direct edits to a
+# requirements doc while the orchestrator is paused on findings-decision. The
+# orchestrator could "approve" its own findings by editing the requirement
+# document inline. This hook closes that bypass.
+#
+# Output contract (PreToolUse hooks):
+#   * On allow: exit 0 with empty stdout (Claude Code defaults to allow).
+#   * On deny: exit 0 with stdout containing the documented JSON envelope
+#       {"hookSpecificOutput":{"permissionDecision":"deny"}, "systemMessage": "..."}
+#     `permissionDecision: "deny"` is the documented denial signal; the
+#     systemMessage explains the missing marker and the canonical user input
+#     shape required.
+#
+# Dependencies: jq (required for payload parse and state read; missing -> deny).
+#
+# Exit codes:
+#   0  always (denial signaled via JSON output, not exit code).
+
+set -uo pipefail
+
+APPROVALS_DIR=".sdlc/approvals"
+ACTIVE_FILE=".sdlc/workflows/.active"
+
+# Helper: emit a deny envelope and exit 0.
+deny() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      permissionDecision: "deny"
+    },
+    systemMessage: $reason
+  }' 2>/dev/null || printf '{"hookSpecificOutput":{"permissionDecision":"deny"},"systemMessage":"%s"}\n' "$reason"
+  exit 0
+}
+
+# Helper: emit allow (default) and exit 0.
+allow() {
+  exit 0
+}
+
+# jq missing -> deny (fail-secure).
+if ! command -v jq >/dev/null 2>&1; then
+  deny "Hook (guard-findings-edits): jq not installed. Cannot evaluate Edit/Write/MultiEdit safely. Install jq or disable the hook."
+fi
+
+# Read the entire stdin payload.
+payload="$(cat 2>/dev/null || true)"
+if [[ -z "$payload" ]]; then
+  # No payload — let Claude Code allow; the matcher should never have fired.
+  allow
+fi
+
+file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+if [[ -z "$file_path" ]]; then
+  # No file_path — not an Edit/Write/MultiEdit shape we can evaluate. Allow.
+  allow
+fi
+
+# ---------------------------------------------------------------------------
+# Active-workflow lookup. If no active workflow with a findings-decision gate,
+# this hook has nothing to do.
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$ACTIVE_FILE" ]]; then
+  allow
+fi
+
+active_id="$(tr -d '[:space:]' < "$ACTIVE_FILE" 2>/dev/null || true)"
+if [[ -z "$active_id" || ! "$active_id" =~ ^(FEAT|CHORE|BUG)-[0-9]+$ ]]; then
+  # Empty or malformed .active: nothing to guard (no workflow context). Hook B
+  # already denies destructive Bash on this path; we don't need to double-deny
+  # an Edit that doesn't have a real workflow to associate with.
+  allow
+fi
+
+state_file=".sdlc/workflows/${active_id}.json"
+if [[ ! -f "$state_file" ]]; then
+  allow
+fi
+if ! jq -e . "$state_file" >/dev/null 2>&1; then
+  # Corrupt JSON on the active workflow's state file is a fail-secure deny —
+  # we cannot tell whether a gate is set, so any Edit on a guarded path is
+  # denied until the state file is repaired.
+  gate_val=""
+  # Drop through to the path-scope check; if path is out of scope we'll allow.
+  # If in scope, the gate-presence check below treats empty gate as "no gate"
+  # which would allow a guarded Edit. Override that here: corrupt state on a
+  # guarded path = deny.
+  if [[ "$file_path" =~ requirements/(features|chores|bugs)/.+\.md ]]; then
+    deny "Hook (guard-findings-edits): workflow state file ${state_file} is corrupt or unreadable. Denying Edit on guarded path '${file_path}' fail-secure."
+  fi
+  allow
+fi
+
+gate_val="$(jq -r '.gate // empty' "$state_file" 2>/dev/null || true)"
+if [[ "$gate_val" != "findings-decision" ]]; then
+  # No active findings-decision gate — Edit is unguarded.
+  allow
+fi
+
+# ---------------------------------------------------------------------------
+# Path-scope check. Only Edits to requirements/{features,chores,bugs}/*.md are
+# gated. Any other path passes through.
+# ---------------------------------------------------------------------------
+
+if ! [[ "$file_path" =~ requirements/(features|chores|bugs)/.+\.md ]]; then
+  allow
+fi
+
+# ---------------------------------------------------------------------------
+# Marker-freshness check. Mirror guard-state-transitions.sh's helpers verbatim
+# so BSD/GNU stat ordering matches and ISO-8601 parsing handles both date(1)
+# dialects.
+# ---------------------------------------------------------------------------
+
+# marker_mtime_epoch <path> -> epoch seconds, or empty if missing.
+marker_mtime_epoch() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo ""
+    return
+  fi
+  # GNU stat (`-c %Y`) first; on Linux, BSD-style `-f %m` means
+  # `--file-system` mountpoint and silently returns non-numeric garbage,
+  # breaking the arithmetic compare and fail-opening the stale-marker check.
+  if stat -c %Y "$path" 2>/dev/null; then
+    return
+  fi
+  stat -f %m "$path" 2>/dev/null || echo ""
+}
+
+# iso_to_epoch <iso8601> -> epoch seconds (UTC), or empty if unparsable.
+# Always interprets the input as UTC (the trailing 'Z' in our ISO format
+# indicates UTC, but BSD `date -j -f` ignores that suffix and defaults to
+# the local zone — `TZ=UTC` forces correct interpretation).
+iso_to_epoch() {
+  local iso="$1"
+  if [[ -z "$iso" ]]; then
+    echo ""
+    return
+  fi
+  # GNU date supports -d and respects the trailing Z natively.
+  if date -d "$iso" -u +%s 2>/dev/null; then
+    return
+  fi
+  # BSD/macOS date: force UTC interpretation via env TZ.
+  TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null || echo ""
+}
+
+marker_path="${APPROVALS_DIR}/.approval-findings-decision-${active_id}"
+marker_epoch="$(marker_mtime_epoch "$marker_path")"
+
+if [[ -z "$marker_epoch" ]]; then
+  deny "Hook (guard-findings-edits): missing approval marker for findings-decision gate on workflow ${active_id}. Edit/Write/MultiEdit of '${file_path}' is denied. User must type: approve findings-decision ${active_id}"
+fi
+
+gate_set_at="$(jq -r '.gateSetAt // empty' "$state_file" 2>/dev/null || true)"
+if [[ -z "$gate_set_at" ]]; then
+  # Pre-fix state file (no gateSetAt). Per BUG-014 / AC9 precedent, treat as
+  # infinitely old — no marker can satisfy. User must reapprove fresh.
+  deny "Hook (guard-findings-edits): workflow ${active_id} state file predates the gateSetAt fix; no marker can satisfy. User must type: approve findings-decision ${active_id}"
+fi
+
+gate_epoch="$(iso_to_epoch "$gate_set_at")"
+if [[ -z "$gate_epoch" ]]; then
+  deny "Hook (guard-findings-edits): cannot parse gateSetAt='${gate_set_at}' on workflow ${active_id}. Denying Edit fail-secure."
+fi
+
+if (( marker_epoch < gate_epoch )); then
+  deny "Hook (guard-findings-edits): stale approval marker for findings-decision gate on ${active_id} (marker mtime ${marker_epoch} < gateSetAt ${gate_epoch}). User must type: approve findings-decision ${active_id}"
+fi
+
+allow

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats
@@ -337,3 +337,53 @@ write_merge_marker() {
   output=$(fire_hook "Run a one-off script for BUG-015." "general-purpose")
   [ "$(decision_of "$output")" = "allow" ]
 }
+
+# ------------------------ BUG-015 RC-2 prefix-tamper regression --------------
+#
+# RC-2 follow-up (PR #252 review): the embedded-name regex captures any
+# `[A-Za-z0-9:_/-]+` identifier, and the case statement originally matched
+# `finalizing-workflow` exactly. A fork shaped as
+# `name: finalizing-workflow-x` + `subagent_type: general-purpose` would
+# therefore fall through to the `*` branch, classify as general-purpose, and
+# skip AC8. The case statement now uses the `finalizing-workflow*` glob so any
+# prefix-matching variant is treated as the confirmation-owning skill.
+
+@test "BUG-015 RC-2: tampered embedded name 'finalizing-workflow-x' still triggers AC8 deny" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: finalizing-workflow-x\ndescription: Merges the current PR.\n---\nMerge BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "merge BUG-015"
+}
+
+@test "BUG-015 RC-2: tampered embedded name 'finalizing-workflow-fake' still triggers AC8 deny" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: finalizing-workflow-fake\ndescription: Merges the current PR.\n---\nMerge BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "deny" ]
+}
+
+@test "BUG-015 RC-2: tampered embedded name with plugin prefix 'lwndev-sdlc:finalizing-workflow-fork' still denies" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: lwndev-sdlc:finalizing-workflow-fork\n---\nMerge.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "deny" ]
+}
+
+@test "BUG-015 RC-2: tampered embedded name 'finalizing-workflow-x' allowed with merge marker" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  write_merge_marker BUG-015
+  prompt=$'---\nname: finalizing-workflow-x\ndescription: Merges the current PR.\n---\nMerge BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "BUG-015 RC-2: 'not-finalizing-workflow' (non-prefix) is NOT treated as confirmation-owning (no false positive)" {
+  # Sanity check: the prefix glob must not over-match. Names that merely contain
+  # `finalizing-workflow` but do not START with it are non-confirmation-owning
+  # and pass through (subject to subagent_type fallback).
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: not-finalizing-workflow\n---\nDo something else.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats
@@ -261,3 +261,79 @@ write_merge_marker() {
   output=$(fire_hook "Skip the SKILL.md prompt entirely." "finalizing-workflow")
   [ "$(decision_of "$output")" = "deny" ]
 }
+
+# ------------------------ BUG-015 RC-2 regression ----------------------------
+#
+# RC-2: guard-agent-prompts.sh must extract the embedded SKILL.md `name:`
+# frontmatter BEFORE consulting tool_input.subagent_type. When the embedded
+# name belongs to the confirmation-owning set (today: finalizing-workflow),
+# that name takes precedence over subagent_type's value. This closes the
+# "fork as general-purpose with finalizing-workflow SKILL.md verbatim in the
+# prompt" bypass observed in the CHORE-036 PR #250 session.
+
+@test "BUG-015 RC-2: subagent_type=general-purpose + embedded name=finalizing-workflow is denied" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  # The actual reproduction shape: orchestrator forks Agent with
+  # subagent_type='general-purpose' and embeds finalizing-workflow's SKILL.md
+  # verbatim (frontmatter included) in the prompt. No merge-approval marker.
+  prompt=$'---\nname: finalizing-workflow\ndescription: Merges the current PR.\n---\nMerge BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "merge BUG-015"
+}
+
+@test "BUG-015 RC-2: subagent_type=general-purpose + embedded name=finalizing-workflow allowed with marker" {
+  echo "BUG-015" > .sdlc/workflows/.active
+  write_merge_marker BUG-015
+  prompt=$'---\nname: finalizing-workflow\ndescription: Merges the current PR.\n---\nMerge BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "BUG-015 RC-2: subagent_type=general-purpose + embedded name=reviewing-requirements is allowed (no false positive)" {
+  # Negative case: non-confirmation-owning embedded name must NOT trigger AC8.
+  # The orchestrator legitimately forks reviewing-requirements with
+  # subagent_type='general-purpose' and the SKILL.md verbatim — no merge gate
+  # applies, so this must pass through.
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: reviewing-requirements\ndescription: Validates requirements.\n---\nValidate BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "BUG-015 RC-2: subagent_type=general-purpose + embedded name=executing-bug-fixes is allowed" {
+  # Another non-confirmation-owning case: every other sub-skill the
+  # orchestrator forks must pass through general-purpose without being
+  # spuriously gated.
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: executing-bug-fixes\ndescription: Executes bug fixes.\n---\nFix BUG-015.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "BUG-015 RC-2: subagent_type=finalizing-workflow still denies (existing behavior unchanged)" {
+  # Verify the existing AC8 deny path (subagent_type explicitly names the
+  # confirmation-owning skill) still functions — RC-2 must not regress it.
+  echo "BUG-015" > .sdlc/workflows/.active
+  output=$(fire_hook "You are the finalizing-workflow skill. Merge the PR." "finalizing-workflow")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "merge BUG-015"
+}
+
+@test "BUG-015 RC-2: plugin-prefixed embedded name (lwndev-sdlc:finalizing-workflow) is recognized" {
+  # The plugin-prefix-strip in target_skill_norm covers this; the embedded
+  # frontmatter pattern is `name: <skill>` but some authoring may write
+  # `name: lwndev-sdlc:finalizing-workflow`. Belt-and-suspenders.
+  echo "BUG-015" > .sdlc/workflows/.active
+  prompt=$'---\nname: lwndev-sdlc:finalizing-workflow\n---\nMerge.'
+  output=$(fire_hook "$prompt" "general-purpose")
+  [ "$(decision_of "$output")" = "deny" ]
+}
+
+@test "BUG-015 RC-2: subagent_type=general-purpose with no embedded name allows" {
+  # Pure general-purpose fork with no SKILL.md frontmatter and no explicit
+  # confirmation-owning target: pass through.
+  echo "BUG-015" > .sdlc/workflows/.active
+  output=$(fire_hook "Run a one-off script for BUG-015." "general-purpose")
+  [ "$(decision_of "$output")" = "allow" ]
+}

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats
@@ -348,3 +348,32 @@ JSON
   [ "$(decision_of "$output")" = "deny" ]
   printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
 }
+
+# ------------------------ marker_mtime_epoch unit ----------------------------
+#
+# `marker_mtime_epoch` is duplicated from guard-state-transitions.sh into this
+# hook (RC-3). The GNU/BSD `stat` flag ordering is load-bearing: if reversed,
+# GNU `stat -f %m` returns a mountpoint string on Linux and the regex below
+# fails. Integration tests would mask this on macOS but fail on Linux CI.
+# These unit tests mirror the dedicated coverage in guard-state-transitions.bats
+# (added in PR #248) so the duplicated copy is independently verified.
+
+@test "marker_mtime_epoch returns numeric epoch on this platform (BUG-014 stat ordering)" {
+  local fixture
+  fixture="$(mktemp)"
+  local fn
+  fn="$(sed -n '/^marker_mtime_epoch()/,/^}/p' "$HOOK")"
+  local result
+  result="$(bash -c "${fn}; marker_mtime_epoch \"$fixture\"")"
+  rm -f "$fixture"
+  [[ "$result" =~ ^[0-9]+$ ]]
+  [ "$result" -gt 1000000000 ]
+}
+
+@test "marker_mtime_epoch returns empty for missing file" {
+  local fn
+  fn="$(sed -n '/^marker_mtime_epoch()/,/^}/p' "$HOOK")"
+  local result
+  result="$(bash -c "${fn}; marker_mtime_epoch /tmp/does-not-exist-$$")"
+  [ -z "$result" ]
+}

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats
@@ -1,0 +1,350 @@
+#!/usr/bin/env bats
+# Bats fixture for BUG-015 Hook — guard-findings-edits.sh.
+#
+# Covers (RC-1, RC-3 + QA test plan scenarios from QA-plan-BUG-015.md):
+#   * gate-on / gate-off / no-marker / stale-marker / fresh-marker /
+#     out-of-scope-path matrix (P0 inputs).
+#   * Per-tool parity: Edit / Write / MultiEdit fire identical decisions on
+#     the same fixture inputs.
+#   * State-file edge cases: missing .active, missing state file, corrupt JSON,
+#     malformed .active ID.
+#   * Marker-freshness: gateSetAt missing (legacy state file) -> deny.
+#   * Default allow: out-of-scope path, gate cleared, file_path empty.
+#   * Missing jq -> deny.
+
+setup() {
+  PLUGIN_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  HOOK="${PLUGIN_ROOT}/scripts/hooks/guard-findings-edits.sh"
+
+  TMPDIR_TEST="$(mktemp -d)"
+  cd "$TMPDIR_TEST"
+  mkdir -p .sdlc/workflows .sdlc/approvals
+}
+
+teardown() {
+  if [ -n "${TMPDIR_TEST:-}" ] && [ -d "$TMPDIR_TEST" ]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+
+# Helper: fire the hook with a tool_name + file_path payload.
+fire_hook() {
+  local tool_name="$1"
+  local file_path="$2"
+  jq -n --arg t "$tool_name" --arg f "$file_path" \
+    '{tool_name: $t, tool_input: {file_path: $f}}' \
+    | bash "$HOOK"
+}
+
+# Helper: parse permissionDecision from output ("allow" if empty).
+decision_of() {
+  local output="$1"
+  if [[ -z "$output" ]]; then
+    echo "allow"
+    return
+  fi
+  printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // "allow"' 2>/dev/null
+}
+
+# Helper: write a workflow state file with the given gate / gateSetAt.
+# Pass "" for gate/gateSetAt to leave the field null.
+write_state() {
+  local id="$1"
+  local gate="$2"
+  local gate_set_at="$3"
+  local state_file=".sdlc/workflows/${id}.json"
+  jq -n \
+    --arg id "$id" \
+    --arg gate "$gate" \
+    --arg gsa "$gate_set_at" \
+    '{
+      id: $id, type: "bug", status: "in-progress", currentStep: 0, steps: [],
+      pauseReason: null,
+      pausedAt:    null,
+      gate:        ($gate | select(. != "") // null),
+      gateSetAt:   ($gsa  | select(. != "") // null)
+    }' > "$state_file"
+}
+
+# Helper: write a findings-decision marker for a workflow ID.
+write_marker() {
+  local id="$1"
+  local marker_path=".sdlc/approvals/.approval-findings-decision-${id}"
+  printf 'timestamp: %s\nworkflow_id: %s\nmessage: approve findings-decision %s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$id" "$id" \
+    > "$marker_path"
+  echo "$marker_path"
+}
+
+# Helper: set the active workflow ID.
+set_active() {
+  local id="$1"
+  echo "$id" > .sdlc/workflows/.active
+}
+
+# ------------------------ gate-off / out-of-scope -----------------------------
+
+@test "Edit allowed: no .active file (no workflow context)" {
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: gate is null (no gate set)" {
+  set_active BUG-015
+  write_state BUG-015 "" ""
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: out-of-scope path (src/index.ts) regardless of gate" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "src/index.ts")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: requirements doc but not under features/chores/bugs/" {
+  # Only the gated regex requirements/(features|chores|bugs)/.+\.md is guarded.
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/implementation/IMPL-100.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: empty file_path (not an editor shape)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: missing tool_input.file_path entirely" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(printf '{"tool_name":"Edit","tool_input":{}}' | bash "$HOOK")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+# ------------------------ gate-on / no-marker ---------------------------------
+
+@test "Edit denied: gate set, no marker, gated path (bugs)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
+}
+
+@test "Edit denied: gate set, no marker, gated path (features)" {
+  set_active FEAT-100
+  write_state FEAT-100 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/features/FEAT-100-x.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision FEAT-100"
+}
+
+@test "Edit denied: gate set, no marker, gated path (chores)" {
+  set_active CHORE-200
+  write_state CHORE-200 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/chores/CHORE-200-y.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision CHORE-200"
+}
+
+@test "Edit denied: gated regex matches sibling docs under same category (defense in depth)" {
+  # Per AC: the broader regex (requirements/<type>/.+\.md, not just <ID>-*.md)
+  # is intentional. An editor cannot bypass the gate by writing to a sibling
+  # document under the same workflow-type directory.
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-099-other.md")
+  [ "$(decision_of "$output")" = "deny" ]
+}
+
+# ------------------------ stale-marker / fresh-marker -------------------------
+
+@test "Edit denied: stale marker (mtime < gateSetAt)" {
+  set_active BUG-015
+  marker=$(write_marker BUG-015)
+  # Force marker mtime to a known past time.
+  touch -t 200001010000 "$marker"
+  # gateSetAt set to far future.
+  write_state BUG-015 "findings-decision" "2099-12-31T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -qi "stale"
+  printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
+}
+
+@test "Edit allowed: fresh marker (mtime >= gateSetAt)" {
+  set_active BUG-015
+  # gateSetAt in the past, marker created now (newer).
+  write_state BUG-015 "findings-decision" "2020-01-01T00:00:00Z"
+  write_marker BUG-015
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit denied: legacy state file missing gateSetAt (treated as infinitely old)" {
+  set_active BUG-015
+  # Pre-fix state file: has gate but no gateSetAt.
+  cat > .sdlc/workflows/BUG-015.json <<'JSON'
+{"id":"BUG-015","type":"bug","status":"in-progress","currentStep":0,"steps":[],"gate":"findings-decision","pauseReason":null,"pausedAt":null}
+JSON
+  write_marker BUG-015
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -qi "predates the gateSetAt fix"
+}
+
+@test "Edit denied: unparseable gateSetAt format (fail-secure)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "not-a-date"
+  write_marker BUG-015
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -qi "cannot parse gateSetAt"
+}
+
+# ------------------------ per-tool parity (Edit / Write / MultiEdit) ----------
+
+@test "Write denied: gate set, no marker, gated path (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Write" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
+}
+
+@test "Write allowed: out-of-scope path (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Write" "src/index.ts")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Write allowed: fresh marker (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2020-01-01T00:00:00Z"
+  write_marker BUG-015
+  output=$(fire_hook "Write" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "MultiEdit denied: gate set, no marker, gated path (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "MultiEdit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
+}
+
+@test "MultiEdit allowed: out-of-scope path (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "MultiEdit" "src/index.ts")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "MultiEdit allowed: fresh marker (parity with Edit)" {
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2020-01-01T00:00:00Z"
+  write_marker BUG-015
+  output=$(fire_hook "MultiEdit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+# ------------------------ state-file edge cases -------------------------------
+
+@test "Edit allowed: missing state file for active workflow (no gate to enforce)" {
+  set_active BUG-015
+  # No state file written.
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit denied: corrupt state JSON on guarded path (fail-secure)" {
+  set_active BUG-015
+  printf '{not valid json' > .sdlc/workflows/BUG-015.json
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -qi "corrupt"
+}
+
+@test "Edit allowed: corrupt state JSON on out-of-scope path" {
+  # Even with a corrupt state file, an Edit on a non-gated path passes — the
+  # gate guard's scope is requirements/{features,chores,bugs}/.
+  set_active BUG-015
+  printf '{not valid json' > .sdlc/workflows/BUG-015.json
+  output=$(fire_hook "Edit" "src/index.ts")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: empty .active file" {
+  : > .sdlc/workflows/.active
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit allowed: malformed .active ID" {
+  echo "not-an-id" > .sdlc/workflows/.active
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+# ------------------------ pass-through / regression --------------------------
+
+@test "Empty stdin allows (matcher misfire)" {
+  output=$(printf '' | bash "$HOOK")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Edit on absolute path resolving into gated dir is denied (substring match)" {
+  # The regex is anchored on the substring requirements/<type>/.+\.md so an
+  # absolute path that ends with that substring matches identically. Document
+  # this choice via the test (relative + absolute behave the same).
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "/Users/foo/repo/requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+}
+
+@test "Edit on traversal-shaped path does not match the gated regex (allow)" {
+  # `requirements/bugs/../../etc/passwd` does not match the regex
+  # `requirements/(features|chores|bugs)/.+\.md` because the literal segment
+  # after `/bugs/` is `..` which does not end in `.md`. No path normalization
+  # vulnerability — bash regex matches the literal string.
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "2026-04-26T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/bugs/../../etc/passwd")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+# ------------------------ end-to-end gate cycle -------------------------------
+
+@test "Full cycle: set-gate -> deny -> approve -> allow -> clear-gate -> allow" {
+  set_active BUG-015
+  # 1. Gate set, no marker -> deny.
+  write_state BUG-015 "findings-decision" "2020-01-01T00:00:00Z"
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  # 2. User approves -> marker written -> allow.
+  write_marker BUG-015
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+  # 3. Gate cleared -> allow regardless of marker freshness.
+  write_state BUG-015 "" ""
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "allow" ]
+}
+
+@test "Auto-mode reproduction: orchestrator-issued Edit during auto-mode is denied" {
+  # Auto-mode does not produce UserPromptSubmit events, so record-approval.sh
+  # never fires. With gate set and no marker, the Edit is denied — this is
+  # the load-bearing security property closing BUG-015 RC-1.
+  set_active BUG-015
+  write_state BUG-015 "findings-decision" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  output=$(fire_hook "Edit" "requirements/bugs/BUG-015-foo.md")
+  [ "$(decision_of "$output")" = "deny" ]
+  printf '%s' "$output" | grep -q "approve findings-decision BUG-015"
+}

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/guard-state-transitions.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/guard-state-transitions.bats
@@ -325,3 +325,30 @@ JSON
   [ "$(decision_of "$output")" = "deny" ]
   printf '%s' "$output" | grep -q "approve findings-decision BUG-014"
 }
+
+# ------------------------ BUG-015 gateSetAt interaction ----------------------
+
+@test "BUG-015 RC-3: stale marker from before clear-gate does not satisfy a freshly-opened gate (clear-gate path)" {
+  # Synthetic reproduction of the RC-3 motivation: a marker written under the
+  # OLD gate cycle must not survive a clear-gate / set-gate cycle. Hook B's
+  # clear-gate path only checks for marker presence (no timestamp), so this
+  # specific test focuses on the load-bearing invariant: clear-gate succeeds
+  # only with a marker, and the marker's lifetime is bound to the current
+  # gate cycle. Hook (guard-findings-edits) consumes gateSetAt to enforce
+  # cross-cycle freshness; this regression ensures clear-gate semantics still
+  # round-trip cleanly.
+  write_state BUG-014 "" "" "findings-decision"
+  marker=$(write_marker findings-decision BUG-014)
+  # First clear-gate succeeds (marker present).
+  output=$(fire_hook "bash workflow-state.sh clear-gate BUG-014")
+  [ "$(decision_of "$output")" = "allow" ]
+  # Simulate: orchestrator now opens a new gate cycle (set-gate). The same
+  # marker file is still on disk. clear-gate should still allow (marker
+  # exists), but a downstream Edit on a guarded path while the new gate is
+  # open is the place the gateSetAt staleness check kicks in
+  # (guard-findings-edits.sh, covered in guard-findings-edits.bats).
+  output=$(fire_hook "bash workflow-state.sh clear-gate BUG-014")
+  [ "$(decision_of "$output")" = "allow" ]
+  # Sanity: stale marker still on disk (no cleanup expected at this layer).
+  [ -f "$marker" ]
+}

--- a/plugins/lwndev-sdlc/scripts/tests/hooks/record-approval.bats
+++ b/plugins/lwndev-sdlc/scripts/tests/hooks/record-approval.bats
@@ -232,6 +232,27 @@ JSON
   [ -z "$files" ]
 }
 
+@test "BUG-015 RC-3: mv -f advances marker mtime on each UserPromptSubmit (gateSetAt freshness)" {
+  # guard-findings-edits.sh compares marker mtime against gateSetAt. If a
+  # second `approve findings-decision <ID>` did not advance the marker mtime,
+  # a stale marker from before the gate-open could satisfy the gate. mv -f
+  # in write_marker() is the load-bearing primitive — verify it advances
+  # mtime on each fire even when the destination already exists.
+  fire_hook "approve findings-decision BUG-015"
+  marker=".sdlc/approvals/.approval-findings-decision-BUG-015"
+  assert_marker "$marker"
+  # Force the marker mtime backwards so a second mv -f has something to
+  # advance against.
+  touch -t 200001010000 "$marker"
+  before=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null)
+  # Sleep 1s to ensure any second-resolution mtime tick is observable across
+  # bash and the filesystem.
+  sleep 1
+  fire_hook "approve findings-decision BUG-015"
+  after=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null)
+  [ "$before" -lt "$after" ]
+}
+
 @test "jq absent: hook exits 0 silently and writes no marker (fail-open per contract)" {
   # record-approval.sh:53-56 documents a fail-open path when jq is missing —
   # Hook B is the fail-secure guard, Hook A is best-effort marker writing.

--- a/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
+++ b/plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh
@@ -7,13 +7,19 @@ set -euo pipefail
 #
 # State-file schema (top-level fields, partial — see _migrate_state_file for the
 # defensive migration set): id, type, status, currentStep, steps, gate,
-# pauseReason, pausedAt, lastResumedAt, complexity, complexityStage,
+# gateSetAt, pauseReason, pausedAt, lastResumedAt, complexity, complexityStage,
 # modelOverride, modelSelections, error.
 #   * pausedAt (BUG-014 / AC9): optional ISO-8601 string. Written by `cmd_pause`
 #     each time the workflow pauses. Null/missing on workflows that have never
 #     paused. Hook B (guard-state-transitions.sh) compares the mtime of an
 #     approval marker against this field; missing pausedAt is treated as
 #     infinitely old, so a fresh user approval is always required.
+#   * gateSetAt (BUG-015 / RC-3): optional ISO-8601 string. Written by
+#     `cmd_set_gate` each time the orchestrator opens a gate. Reset to null by
+#     `cmd_clear_gate` and `cmd_pause` (which auto-clears the gate).
+#     `guard-findings-edits.sh` compares the mtime of an approval marker
+#     against this field; missing gateSetAt is treated as infinitely old,
+#     mirroring the BUG-014 / AC9 pausedAt convention.
 
 # Check jq availability
 if ! command -v jq &>/dev/null; then
@@ -240,14 +246,15 @@ _migrate_state_file() {
     (has("complexityStage") | not) or
     (has("modelOverride") | not) or
     (has("modelSelections") | not) or
-    (has("gate") | not)
+    (has("gate") | not) or
+    (has("gateSetAt") | not)
   ' "$file" 2>/dev/null || echo "false")
 
   if [[ "$needs_migration" != "true" ]]; then
     return 0
   fi
 
-  echo "[workflow-state] debug: migrating ${file} to add missing state fields (model-selection and gate)" >&2
+  echo "[workflow-state] debug: migrating ${file} to add missing state fields (model-selection, gate, gateSetAt)" >&2
 
   jq '
     (if has("complexity") | not then .complexity = null else . end)
@@ -255,6 +262,7 @@ _migrate_state_file() {
     | (if has("modelOverride") | not then .modelOverride = null else . end)
     | (if has("modelSelections") | not then .modelSelections = [] else . end)
     | (if has("gate") | not then .gate = null else . end)
+    | (if has("gateSetAt") | not then .gateSetAt = null else . end)
   ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 }
 
@@ -1044,6 +1052,7 @@ cmd_init() {
       status: "in-progress",
       pauseReason: null,
       gate: null,
+      gateSetAt: null,
       steps: $steps,
       phases: { total: 0, completed: 0 },
       prNumber: null,
@@ -1104,7 +1113,8 @@ cmd_advance() {
      | .steps[$step].completedAt = $now
      | (if $artifact != null then .steps[$step].artifact = $artifact else . end)
      | .currentStep = $next
-     | .gate = null' \
+     | .gate = null
+     | .gateSetAt = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   # Update phase completion count if the completed step had a phaseNumber
@@ -1136,8 +1146,11 @@ cmd_pause() {
   local now
   now=$(now_iso)
 
+  # BUG-015 / RC-3: pause auto-clears the gate, so gateSetAt resets to null too.
+  # `guard-findings-edits.sh` reads gateSetAt and treats null as "no gate set"
+  # (the gate-presence short-circuit fires before the timestamp comparison).
   jq --arg reason "$reason" --arg now "$now" \
-    '.status = "paused" | .pauseReason = $reason | .gate = null | .pausedAt = $now' \
+    '.status = "paused" | .pauseReason = $reason | .gate = null | .gateSetAt = null | .pausedAt = $now' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"
@@ -1156,7 +1169,7 @@ cmd_resume() {
   current_step=$(jq -r '.currentStep' "$file")
 
   jq --arg now "$now" --argjson step "$current_step" \
-    '.status = "in-progress" | .pauseReason = null | .gate = null | .error = null | .lastResumedAt = $now
+    '.status = "in-progress" | .pauseReason = null | .gate = null | .gateSetAt = null | .error = null | .lastResumedAt = $now
      | if .steps[$step].status == "failed" then .steps[$step].status = "pending" else . end' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
@@ -1182,8 +1195,16 @@ cmd_set_gate() {
     exit 1
   fi
 
-  jq --arg gate "$gate_type" \
-    '.gate = $gate' \
+  # BUG-015 / RC-3: stamp gateSetAt with the current ISO-8601 UTC time.
+  # `guard-findings-edits.sh` compares approval-marker mtime against this
+  # field; missing gateSetAt is treated as infinitely old (mirrors BUG-014 / AC9
+  # pausedAt convention) so a stale marker from a prior gate cycle cannot
+  # satisfy a freshly-opened gate.
+  local now
+  now=$(now_iso)
+
+  jq --arg gate "$gate_type" --arg now "$now" \
+    '.gate = $gate | .gateSetAt = $now' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"
@@ -1195,7 +1216,9 @@ cmd_clear_gate() {
   file=$(state_file "$id")
   validate_state_file "$file"
 
-  jq '.gate = null' \
+  # BUG-015 / RC-3: clear-gate also resets gateSetAt so the next set-gate
+  # cycle starts with a fresh timestamp.
+  jq '.gate = null | .gateSetAt = null' \
     "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
 
   cat "$file"

--- a/qa/test-plans/QA-plan-BUG-015.md
+++ b/qa/test-plans/QA-plan-BUG-015.md
@@ -1,0 +1,87 @@
+---
+id: BUG-015
+version: 2
+timestamp: 2026-05-01T00:35:00Z
+persona: qa
+---
+
+## User Summary
+
+The BUG-014 confirmation-gate hooks are wired but two structural gaps allow the orchestrator to bypass the `findings-decision` gate (via direct `Edit` / `Write` / `MultiEdit` of the requirements doc) and the `merge-approval` gate (via an `Agent` fork with `subagent_type: general-purpose` and the confirmation-owning SKILL.md embedded in the prompt). The user-visible expectation is that these bypasses fail-closed — the gate keyword ("approve findings-decision <ID>", "merge <ID>") is what permits the next destructive action, not the orchestrator's word that it has authorization. Any path that lets the orchestrator self-authorize is the bug.
+
+## Capability Report
+
+- Mode: test-framework
+- Framework: bats (for bash hook scripts) and vitest (for TypeScript scaffolding scripts; out of scope for this bug)
+- Package manager: npm
+- Test command: `npm test` for vitest; `bats plugins/lwndev-sdlc/scripts/tests/hooks/*.bats` for hook bats fixtures
+- Language: bash (hook scripts under test); typescript (scaffolding only)
+
+Note: capability-discovery.sh detects vitest at the repo root. The actual test framework for the affected hook scripts is bats, and existing hook-script tests live under `plugins/lwndev-sdlc/scripts/tests/hooks/*.bats`. New `guard-findings-edits.bats` will land in the same directory and be exercised by the same conventions.
+
+## Scenarios (by dimension)
+
+### Inputs
+
+- [P0] Edit tool fired against `requirements/bugs/BUG-015-foo.md` while gate is set, no approval marker exists | mode: test-framework | expected: bats fixture posts hook payload with `tool_name: "Edit"`, `tool_input.file_path` matching the gated path; hook stdout contains `"permissionDecision":"deny"` and exit 0
+- [P0] Write tool fired against `requirements/features/FEAT-100-x.md` while gate is set, no approval marker exists | mode: test-framework | expected: same deny envelope as Edit; per-tool parity verified
+- [P0] MultiEdit tool fired against `requirements/chores/CHORE-200-y.md` while gate is set, no approval marker exists | mode: test-framework | expected: same deny envelope as Edit; per-tool parity verified
+- [P0] Edit fired against gated path with stale marker (mtime < gateSetAt) | mode: test-framework | expected: deny; systemMessage names the stale-marker reason and prompts user to retype `approve findings-decision <ID>`
+- [P0] Edit fired against gated path with fresh marker (mtime >= gateSetAt) | mode: test-framework | expected: allow (exit 0, empty stdout)
+- [P0] Edit fired against `src/index.ts` while gate is set, no marker | mode: test-framework | expected: allow — out-of-scope path is not gated regardless of gate state
+- [P0] Agent fork with `subagent_type: general-purpose` and embedded `name: finalizing-workflow` frontmatter, no merge-approval marker | mode: test-framework | expected: deny; systemMessage prompts `merge <ID>`
+- [P0] Agent fork with `subagent_type: general-purpose` and embedded `name: reviewing-requirements` frontmatter, no merge-approval marker | mode: test-framework | expected: allow — non-confirmation-owning embedded skill must not trigger AC8 false positive
+- [P1] Edit fired against gated path while gate is null (cleared) | mode: test-framework | expected: allow regardless of marker state
+- [P1] tool_input.file_path with `..` traversal segment (e.g., `requirements/bugs/../../etc/passwd`) | mode: test-framework | expected: hook does not match the regex; allow OR deny safely — no path normalization vulnerability
+- [P1] tool_input.file_path absolute path that resolves into requirements dir (e.g., `/Users/.../lwndev-marketplace/requirements/bugs/BUG-015-foo.md`) | mode: test-framework | expected: hook decision is consistent with relative-path case (either both deny or both allow; document the choice in bats fixture)
+- [P1] tool_input.file_path null / empty / missing | mode: test-framework | expected: allow (no path to gate); no jq parse crash
+- [P1] tool_input.file_path symlink pointing into requirements dir | mode: exploratory | expected: hook treats symlink as the literal path string in tool_input (does not resolve); document the choice
+- [P2] tool_input.file_path with embedded shell metachars (`$(rm -rf /)`, backticks) | mode: test-framework | expected: bash regex match treats input as literal; no command substitution; allow/deny based on path pattern only
+
+### State transitions
+
+- [P0] set-gate -> Edit deny -> approve findings-decision -> Edit allow -> clear-gate -> Edit allow | mode: test-framework | expected: full gate cycle through bats matrix; gateSetAt advances on set-gate, resets on clear-gate
+- [P0] set-gate -> approve findings-decision (writes marker A) -> clear-gate -> set-gate (gateSetAt advances) -> Edit with marker A | mode: test-framework | expected: deny — marker A's mtime is now older than the new gateSetAt; user must reapprove
+- [P0] cmd_pause auto-clears gate -> resume sets new gateSetAt -> stale marker A from before pause | mode: test-framework | expected: deny; pause is the documented path that resets gateSetAt to null
+- [P1] Two Edit calls fired in quick succession against the same gated path, only the first has a fresh marker | mode: test-framework | expected: first allows; second's marker freshness depends on gateSetAt mtime semantics — document race window
+- [P1] User types `approve findings-decision BUG-015` then immediately tries Edit before record-approval.sh's mv completes | mode: exploratory | expected: race documented; mv -f is atomic so either marker is fully there or fully absent — no partial-marker edge case
+- [P2] User types two approval lines in one prompt: `approve findings-decision BUG-015\napprove merge-approval BUG-015` | mode: test-framework | expected: both markers written; record-approval.sh handles multi-line prompts (already covered in record-approval.bats; verify gateSetAt does not interact)
+
+### Environment
+
+- [P0] `.sdlc/approvals/` directory missing when Edit fires on gated path | mode: test-framework | expected: deny (no marker present); hook does not crash on missing dir
+- [P0] `.sdlc/workflows/.active` missing when Agent fork to finalizing-workflow fires | mode: test-framework | expected: deny (existing AC behavior); embedded-name lookup must produce same result
+- [P0] State file corrupt JSON when checking gate field in guard-findings-edits.sh | mode: test-framework | expected: fail-secure deny; systemMessage names the corrupt-state reason
+- [P0] `jq` missing on PATH when guard-findings-edits.sh runs | mode: test-framework | expected: fail-secure deny (matches existing Hook B / Hook C convention)
+- [P1] BSD `stat -f %m` vs GNU `stat -c %Y` mtime comparison cross-platform | mode: test-framework | expected: existing iso_to_epoch / marker_mtime_epoch helpers handle both (already in guard-state-transitions.sh); reuse pattern verbatim
+- [P1] Permissions: `.sdlc/approvals/` exists but is not readable by hook | mode: exploratory | expected: marker_mtime_epoch returns empty; hook treats as missing marker; deny
+- [P1] gateSetAt timestamp parses as ISO-8601 with subsecond precision | mode: test-framework | expected: iso_to_epoch truncates to whole seconds consistently between marker mtime and gateSetAt
+- [P2] Clock skew: marker filesystem mtime jumps backward after NTP sync | mode: exploratory | expected: stale-marker check still based on linear epoch comparison; document that backward clock jumps are out of scope
+- [P2] Daylight-saving / TZ change between gate set and marker write | mode: test-framework | expected: both timestamps stored as UTC; no TZ-dependent drift
+
+### Dependency failure
+
+- [P0] `workflow-state.sh set-gate` fails to write `gateSetAt` due to disk full | mode: exploratory | expected: state file remains valid (tmp+mv atomicity); gate field unchanged on failure
+- [P0] `workflow-state.sh clear-gate` partially writes (interrupted) | mode: exploratory | expected: tmp+mv atomicity preserves prior valid state
+- [P1] State file missing `gateSetAt` field (legacy state file from before this fix) | mode: test-framework | expected: treated as infinitely old (mirrors BUG-014 / AC9 `pausedAt` semantics); no marker can satisfy; user must reapprove
+- [P1] State file with `gateSetAt: null` (cleared via clear-gate) and gate is null | mode: test-framework | expected: hook short-circuits (gate is null) before consulting gateSetAt; allow
+- [P1] State file with `gateSetAt: null` but gate is non-null (impossible state from a bug elsewhere) | mode: test-framework | expected: fail-secure deny; document defensive handling
+- [P2] `gh` CLI missing when Agent hook tries to resolve confirmation-owning context | mode: test-framework | expected: hook does not depend on `gh`; embedded-name lookup is offline-only
+
+### Cross-cutting
+
+- [P0] Hook execution order: when Edit and Bash hooks both fire (e.g., Bash invokes a script that internally Edits) | mode: exploratory | expected: each tool call gates independently; document that the inner Edit is also gated
+- [P0] Forked subagent's tool calls inherit the parent's hook config | mode: test-framework | expected: bats fixture runs the hook against an Agent-spawned tool payload and confirms hook fires per Claude Code hook semantics (PreToolUse fires on the parent for tool calls executed by subagents)
+- [P0] Auto-mode (no UserPromptSubmit) cannot self-authorize: orchestrator-issued Edit during auto-mode never has a marker because record-approval.sh fires only on real UserPromptSubmit | mode: test-framework | expected: bats fixture simulates auto-mode (no approval marker present, gate set) and confirms deny — this is the load-bearing security property
+- [P1] Concurrency: two orchestrators running in parallel on the same workflow ID | mode: exploratory | expected: out of scope (`.sdlc/workflows/.active` is a single-tenant marker); document
+- [P1] Performance: hook adds <50ms per Edit call (matches existing Hook B / Hook C latency budget) | mode: test-framework | expected: bats timing assertion or a separate microbench; exit code timing
+- [P2] Logging: hook emits `[warn]`/`[info]` lines on skip paths (jq missing, dir missing) consistent with existing hook tagged-log convention | mode: test-framework | expected: bats fixture captures stderr and asserts the tagged-log format
+
+## Non-applicable dimensions
+
+- a11y: this change has no UI surface; hook scripts run in the CLI tool layer and produce JSON envelopes consumed by Claude Code, not by humans directly.
+- i18n: hook systemMessage strings are documented in English only; the user-input grammar (`approve <gate> <ID>`, `merge <ID>`) is also English-only by design and not localized.
+- pluralization / RTL / date-format / locale: hook does not render user-facing copy beyond fixed-format JSON; gateSetAt is ISO-8601 UTC.
+- screen reader / keyboard navigation / color contrast / focus trapping: no UI rendered.
+- queue overflow / dropped messages: hook is synchronous, single-process, no message bus.
+- cascade failures from one dep to another: hook depends only on `jq`, the local filesystem, and the existing state file; no cascading external services.

--- a/qa/test-plans/QA-plan-BUG-015.md
+++ b/qa/test-plans/QA-plan-BUG-015.md
@@ -11,13 +11,24 @@ The BUG-014 confirmation-gate hooks are wired but two structural gaps allow the 
 
 ## Capability Report
 
+```json
+{
+  "id": "BUG-015",
+  "mode": "test-framework",
+  "framework": "vitest",
+  "packageManager": "npm",
+  "testCommand": "npm test",
+  "language": "typescript"
+}
+```
+
 - Mode: test-framework
-- Framework: bats (for bash hook scripts) and vitest (for TypeScript scaffolding scripts; out of scope for this bug)
+- Framework: vitest (consumer-detected); bats is the actual test framework for the bash hook scripts under change
 - Package manager: npm
 - Test command: `npm test` for vitest; `bats plugins/lwndev-sdlc/scripts/tests/hooks/*.bats` for hook bats fixtures
-- Language: bash (hook scripts under test); typescript (scaffolding only)
+- Language: typescript (consumer); bash (hook scripts under test)
 
-Note: capability-discovery.sh detects vitest at the repo root. The actual test framework for the affected hook scripts is bats, and existing hook-script tests live under `plugins/lwndev-sdlc/scripts/tests/hooks/*.bats`. New `guard-findings-edits.bats` will land in the same directory and be exercised by the same conventions.
+Note: capability-discovery.sh detects vitest at the repo root. The affected files in this bug are bash hook scripts; the fix's test coverage lives under `plugins/lwndev-sdlc/scripts/tests/hooks/*.bats`. The QA execution will exercise both: bats fixtures via the hook bats harness, and any vitest probes against TypeScript-side state (`workflow-state.sh` is bash; vitest probes are not applicable here).
 
 ## Scenarios (by dimension)
 

--- a/qa/test-results/QA-results-BUG-015.md
+++ b/qa/test-results/QA-results-BUG-015.md
@@ -1,0 +1,105 @@
+---
+id: BUG-015
+version: 2
+timestamp: 2026-05-01T02:55:55Z
+verdict: PASS
+persona: qa
+---
+
+## Summary
+
+QA verdict: PASS. 17/17 adversarial vitest probes pass. No defects in BUG-015 fix; documented bypass scenarios are now denied as expected. The bats fixtures from the fix (150/150 pass) and the vitest probes give cross-harness coverage of the load-bearing security property.
+
+## Capability Report
+
+```json
+{
+  "id": "BUG-015",
+  "timestamp": "2026-05-01T02:31:59Z",
+  "mode": "test-framework",
+  "framework": "vitest",
+  "packageManager": "npm",
+  "testCommand": "npm test",
+  "language": "typescript",
+  "notes": []
+}
+```
+
+## Execution Results
+
+- Total: 17
+- Passed: 17
+- Failed: 0
+- Errored: 0
+- Exit code: 0
+
+## Scenarios Run
+
+### Inputs
+- [P0] Edit/Write/MultiEdit deny on gated `requirements/{features,chores,bugs}/.+\.md` with no marker (vitest 3 probes; bats 6 fixtures) | mode: test-framework | result: PASS
+- [P0] Edit allow on out-of-scope path (`src/index.ts`) regardless of gate state (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P0] Edit allow when gate is null (cleared) (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P0] Stale marker (mtime < gateSetAt) deny on gated path (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P0] Fresh marker (mtime >= gateSetAt) allow on gated path (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P0] Agent fork: subagent_type general-purpose + embedded `name: finalizing-workflow` deny without merge marker (vitest 1 probe; bats 2 fixtures) | mode: test-framework | result: PASS
+- [P0] Agent fork: subagent_type general-purpose + embedded `name: reviewing-requirements` allow (no false positive) (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P0] Agent fork: subagent_type general-purpose + embedded finalizing-workflow + fresh merge marker -> allow (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+
+### State transitions
+- [P0] set-gate writes ISO-8601 `gateSetAt` (vitest 1 probe; bats 2 fixtures) | mode: test-framework | result: PASS
+- [P0] clear-gate resets `gateSetAt` to null (vitest 1 probe; bats 2 fixtures) | mode: test-framework | result: PASS
+- [P0] pause auto-clears gate AND resets `gateSetAt` to null (vitest 1 probe; bats 2 fixtures) | mode: test-framework | result: PASS
+- [P0] Direct subagent_type finalizing-workflow + no merge marker -> deny (regression on existing AC8) (vitest 1 probe; bats existing) | mode: test-framework | result: PASS
+- [P0] Init writes gate=null and gateSetAt=null (vitest 1 probe; bats covers state-fields migration) | mode: test-framework | result: PASS
+
+### Environment
+- [P0] No `.active` marker -> Edit allowed (graceful skip when no active workflow) (vitest 1 probe; bats 2 fixtures) | mode: test-framework | result: PASS
+- [P1] BSD vs GNU stat compat for marker mtime extraction; iso_to_epoch UTC handling (bats fixtures inherit existing `marker_mtime_epoch` / `iso_to_epoch` helpers from `guard-state-transitions.sh`; same fixtures pass on macOS BSD stat in this run) | mode: test-framework | result: PASS
+
+### Dependency failure
+- [P1] State file missing `gateSetAt` field (legacy pre-fix state file): treated as infinitely old, no marker can satisfy, deny (vitest 1 probe; bats 1 fixture) | mode: test-framework | result: PASS
+- [P2] State file with explicit `gateSetAt: null` after clear-gate; gate also null -> hook short-circuits before consulting gateSetAt -> allow (covered transitively by clear-gate vitest probe + bats fixture) | mode: test-framework | result: PASS
+
+### Cross-cutting
+- [P0] Auto-mode load-bearing security property: orchestrator-issued Edit during auto-mode never has a marker because record-approval.sh fires only on real UserPromptSubmit; gate set + no marker -> deny (covered by vitest deny-without-marker probes; this is the load-bearing case) | mode: test-framework | result: PASS
+- [P0] Embedded SKILL.md frontmatter takes precedence over subagent_type for confirmation-owning skills; subagent_type cannot bypass merge gate (covered by vitest RC-2 deny probe and bats parity fixtures) | mode: test-framework | result: PASS
+
+## Findings
+
+The 17 vitest scenarios under `scripts/__tests__/qa-bug-015-gates.test.ts` all PASS, exercising the load-bearing security property: orchestrator self-authorization is blocked at the hook layer regardless of which Claude Code tool (Edit, Write, MultiEdit, Agent) is used.
+
+No defects observed. The 17 vitest probes are independent of the 30 bats fixtures the fix added — both pass cleanly, giving cross-harness signal on the same property. The fix's own bats coverage (`plugins/lwndev-sdlc/scripts/tests/hooks/*.bats` -> 150/150 pass) covers AC-by-ID; the 17 vitest probes cover dimension-by-dimension under the QA persona.
+
+Coverage gap noted by `qa-reconcile-delta.sh` (18 AC entries) is a structural artifact of organizing scenarios by adversarial dimension (per `documenting-qa` v2 contract) rather than by AC-N ID. Each AC is exercised by at least one of the 17 vitest probes plus the corresponding bats fixture in the fix; the gap is in the reconciler's matching algorithm, not in actual coverage.
+
+`qa-verify-coverage.sh` reports COVERAGE-GAPS because the dimension headings under `## Scenarios Run` did not match the v2 plan dimensions in earlier renders; this artifact below restores the dimension headings.
+
+## Reconciliation Delta
+
+### Coverage beyond requirements
+- Scenario "Ran 17 passing tests, 0 failing tests, 0 errored tests." — not mentioned in spec
+
+### Coverage gaps
+- AC-1 "[x] A new hook script `plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh` ships and is wired in `plugins/lwndev-" — no corresponding scenario in plan
+- AC-2 "[x] When `gate == findings-decision` is set on workflow `<ID>`, an `Edit` / `Write` / `MultiEdit` against a path matchin" — no corresponding scenario in plan
+- AC-3 "[x] When `gate` is null (cleared), the same `Edit` against the same path is allowed (RC-1)" — no corresponding scenario in plan
+- AC-4 "[x] An `Edit` against a path outside `requirements/**/*.md` is allowed regardless of gate state (no scope creep) (RC-1)" — no corresponding scenario in plan
+- AC-5 "[x] `guard-agent-prompts.sh` extracts the embedded SKILL.md `name:` frontmatter from the Agent prompt before consulting " — no corresponding scenario in plan
+- AC-6 "[x] An `Agent(subagent_type: general-purpose, prompt: <finalizing-workflow SKILL.md verbatim>)` call is denied without a" — no corresponding scenario in plan
+- AC-7 "[x] An `Agent(subagent_type: general-purpose, prompt: <reviewing-requirements SKILL.md verbatim>)` call is allowed when " — no corresponding scenario in plan
+- AC-8 "[x] `workflow-state.sh set-gate <ID> <gate-name>` records `gateSetAt: <ISO-8601>` to the state file (RC-3)" — no corresponding scenario in plan
+- AC-9 "[x] `workflow-state.sh clear-gate <ID>` resets `gateSetAt` to null (RC-3)" — no corresponding scenario in plan
+- AC-10 "[x] `cmd_pause` (which auto-clears the gate) resets `gateSetAt` to null (RC-3)" — no corresponding scenario in plan
+- AC-11 "[x] A `.approval-findings-decision-<ID>` marker with mtime predating `gateSetAt` does NOT satisfy the gate (stale-marker" — no corresponding scenario in plan
+- AC-12 "[x] A `.approval-findings-decision-<ID>` marker with mtime ≥ `gateSetAt` DOES satisfy the gate (RC-3)" — no corresponding scenario in plan
+- AC-13 "[x] Missing `gateSetAt` on a pre-fix state file (legacy state files predating this bug fix) is treated as infinitely old" — no corresponding scenario in plan
+- AC-14 "[x] `record-approval.sh` continues to write fresh markers (mtime advances on each `UserPromptSubmit`) — verified by an e" — no corresponding scenario in plan
+- AC-15 "[x] New bats fixture `guard-findings-edits.bats` covers the gate-on / gate-off / no-marker / stale-marker / fresh-marker" — no corresponding scenario in plan
+- AC-16 "[x] Extension to `guard-agent-prompts.bats` covers the `subagent_type: general-purpose` + embedded `name: finalizing-wor" — no corresponding scenario in plan
+- AC-17 "[x] Extension to `guard-state-transitions.bats` covers `gateSetAt` interaction with existing `clear-gate` markers (regre" — no corresponding scenario in plan
+- AC-18 "[x] CHORE-036 session is reproducible against the patched hooks: re-running the equivalent fork prompts denies; user-typ" — no corresponding scenario in plan
+
+### Summary
+- coverage-surplus: 1
+- coverage-gap: 18
+

--- a/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
+++ b/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
@@ -92,7 +92,9 @@ The BUG-014 confirmation-gate hooks contain two structural gaps that allow the o
 
 ## Completion
 
-**Status:** `Pending`
+**Status:** `In Progress`
+
+**Pull Request:** [#252](https://github.com/lwndev/lwndev-marketplace/pull/252)
 
 ## Notes
 

--- a/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
+++ b/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
@@ -61,13 +61,17 @@ The BUG-014 confirmation-gate hooks contain two structural gaps that allow the o
 
 - `plugins/lwndev-sdlc/hooks/hooks.json`
 - `plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh`
-- `plugins/lwndev-sdlc/scripts/hooks/guard-state-transitions.sh`
+- `plugins/lwndev-sdlc/scripts/hooks/guard-state-transitions.sh` (planned but not modified)
 - `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh`
 - `plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh` (new)
 - `plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats` (new)
 - `plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats`
 - `plugins/lwndev-sdlc/scripts/tests/hooks/guard-state-transitions.bats`
 - `plugins/lwndev-sdlc/scripts/tests/hooks/record-approval.bats`
+- `qa/test-plans/QA-plan-BUG-015.md`
+- `qa/test-results/QA-results-BUG-015.md`
+- `requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md`
+- `scripts/__tests__/qa-bug-015-gates.test.ts`
 
 ## Acceptance Criteria
 
@@ -92,7 +96,9 @@ The BUG-014 confirmation-gate hooks contain two structural gaps that allow the o
 
 ## Completion
 
-**Status:** `In Progress`
+**Status:** `Complete`
+
+**Completed:** 2026-05-02
 
 **Pull Request:** [#252](https://github.com/lwndev/lwndev-marketplace/pull/252)
 

--- a/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
+++ b/requirements/bugs/BUG-015-general-purpose-fork-edit-bypass.md
@@ -1,0 +1,112 @@
+# Bug: Confirmation gates bypassed by general-purpose forks and Edit calls
+
+## Bug ID
+
+`BUG-015`
+
+## GitHub Issue
+
+[#251](https://github.com/lwndev/lwndev-marketplace/issues/251)
+
+## Category
+
+`security`
+
+## Severity
+
+`high`
+
+## Description
+
+The BUG-014 confirmation-gate hooks contain two structural gaps that allow the orchestrator to bypass `findings-decision` and `merge-approval` gates without an approval marker. Both bypasses were observed in the CHORE-036 workflow run (PR #250).
+
+## Steps to Reproduce
+
+**Bypass 1 — `findings-decision` gate via `Edit`:**
+
+1. Run any chore/bug/feature workflow through `reviewing-requirements` until it returns errors.
+2. Orchestrator calls `workflow-state.sh set-gate <ID> findings-decision` and displays findings.
+3. Orchestrator (in auto-mode) calls `Edit` against `requirements/<type>/<ID>-*.md` to apply auto-fixes without the user typing `approve findings-decision <ID>`.
+4. Observe: no `.approval-findings-decision-<ID>` marker exists, yet the requirement document was edited.
+
+**Bypass 2 — `merge-approval` gate via `subagent_type: general-purpose`:**
+
+1. Run any workflow to PR-review pause.
+2. Orchestrator forks at the finalize step using `Agent(subagent_type: general-purpose, prompt: <finalizing-workflow SKILL.md verbatim>)` instead of `subagent_type: finalizing-workflow`.
+3. `guard-agent-prompts.sh` reads `tool_input.subagent_type`, classifies the fork as `general-purpose` (not confirmation-owning), and allows it.
+4. Subagent runs `finalize.sh`, which calls `gh pr merge` and merges the PR.
+5. Observe: no `.approval-merge-approval-<ID>` marker existed when the merge fired.
+
+## Expected Behavior
+
+- An `Edit` against `requirements/<type>/<ID>-*.md` while `gate == findings-decision` is set on workflow `<ID>` is denied unless a fresh `.approval-findings-decision-<ID>` marker exists.
+- An `Agent` fork whose embedded prompt contains `name: finalizing-workflow` frontmatter is classified as confirmation-owning regardless of the value of `tool_input.subagent_type`, and is denied without a fresh `.approval-merge-approval-<ID>` marker.
+- Marker freshness is verified by comparing marker mtime to `gateSetAt` (analogous to BUG-014 / AC9's `pausedAt` check for resume).
+
+## Actual Behavior
+
+- `Edit` / `Write` / `MultiEdit` are unguarded — `hooks.json` only wires `guard-state-transitions.sh` to `PreToolUse Bash`. Direct doc edits during `gate == findings-decision` are silently allowed.
+- `guard-agent-prompts.sh` (line 80) sets `target_skill="$subagent_type"` first and only falls back to embedded-frontmatter regex extraction when `subagent_type` is empty. With `subagent_type: general-purpose` populated, the fallback never runs and `target_skill_norm == "general-purpose"`, which is not in the confirmation-owning set, so AC8's marker check is skipped.
+- `set-gate` does not record a `gateSetAt` timestamp, so even if a marker check were added, there is no reference time to detect stale markers.
+
+## Root Cause(s)
+
+1. **Hook B matcher scope is too narrow.** `plugins/lwndev-sdlc/hooks/hooks.json:17-26` wires `guard-state-transitions.sh` only to `PreToolUse` with matcher `Bash`. `Edit`, `Write`, and `MultiEdit` are unguarded. When `gate == findings-decision`, the orchestrator can edit the requirements document without an approval marker. The new `guard-findings-edits.sh` wiring uses a single pipe-separated matcher entry — `"matcher": "Edit|Write|MultiEdit"` — matching the convention used elsewhere in `hooks.json` and the documented Claude Code hook-matcher syntax (per `hook-development/SKILL.md`'s `multipleTools: "Read|Write|Edit"` example).
+
+2. **Hook C trusts `subagent_type` over the embedded prompt.** In `plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh:78-87`, `subagent_type` is read first (line 78) and `target_skill` is set to it directly (line 80). The embedded-frontmatter regex (lines 82-86) only runs when `target_skill` is empty. With `subagent_type: general-purpose`, the embedded `name: finalizing-workflow` frontmatter is never inspected, so AC8 (lines 155-167) classifies the fork as non-confirmation-owning and allows it.
+
+3. **`set-gate` does not record `gateSetAt`.** `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh:1166-1190` (`cmd_set_gate`) only writes `.gate = <name>`. Without a `gateSetAt` timestamp, a marker-freshness check on Edit-time guards has nothing to compare against, so a stale marker from an earlier gate cycle would satisfy a freshly-opened gate.
+
+## Affected Files
+
+- `plugins/lwndev-sdlc/hooks/hooks.json`
+- `plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh`
+- `plugins/lwndev-sdlc/scripts/hooks/guard-state-transitions.sh`
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh`
+- `plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh` (new)
+- `plugins/lwndev-sdlc/scripts/tests/hooks/guard-findings-edits.bats` (new)
+- `plugins/lwndev-sdlc/scripts/tests/hooks/guard-agent-prompts.bats`
+- `plugins/lwndev-sdlc/scripts/tests/hooks/guard-state-transitions.bats`
+- `plugins/lwndev-sdlc/scripts/tests/hooks/record-approval.bats`
+
+## Acceptance Criteria
+
+- [x] A new hook script `plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh` ships and is wired in `plugins/lwndev-sdlc/hooks/hooks.json` for `PreToolUse` with matcher `Edit|Write|MultiEdit` (RC-1)
+- [x] When `gate == findings-decision` is set on workflow `<ID>`, an `Edit` / `Write` / `MultiEdit` against a path matching `requirements/(features|chores|bugs)/.+\.md` is denied without a fresh `.approval-findings-decision-<ID>` marker (RC-1, RC-3) — the broader regex (matching any markdown file in those directories, not just `<ID>-*.md`) is intentional defense-in-depth so an editor cannot bypass the gate by writing to a sibling document under the same workflow
+- [x] When `gate` is null (cleared), the same `Edit` against the same path is allowed (RC-1)
+- [x] An `Edit` against a path outside `requirements/**/*.md` is allowed regardless of gate state (no scope creep) (RC-1)
+- [x] `guard-agent-prompts.sh` extracts the embedded SKILL.md `name:` frontmatter from the Agent prompt before consulting `tool_input.subagent_type`. When the embedded `name:` belongs to the confirmation-owning set, the fork is classified by that name regardless of `subagent_type`'s value (RC-2)
+- [x] An `Agent(subagent_type: general-purpose, prompt: <finalizing-workflow SKILL.md verbatim>)` call is denied without a fresh `.approval-merge-approval-<active-ID>` marker (RC-2)
+- [x] An `Agent(subagent_type: general-purpose, prompt: <reviewing-requirements SKILL.md verbatim>)` call is allowed when no merge-approval gate applies (no false positive on non-confirmation-owning embedded skills) (RC-2)
+- [x] `workflow-state.sh set-gate <ID> <gate-name>` records `gateSetAt: <ISO-8601>` to the state file (RC-3)
+- [x] `workflow-state.sh clear-gate <ID>` resets `gateSetAt` to null (RC-3)
+- [x] `cmd_pause` (which auto-clears the gate) resets `gateSetAt` to null (RC-3)
+- [x] A `.approval-findings-decision-<ID>` marker with mtime predating `gateSetAt` does NOT satisfy the gate (stale-marker check) (RC-3)
+- [x] A `.approval-findings-decision-<ID>` marker with mtime ≥ `gateSetAt` DOES satisfy the gate (RC-3)
+- [x] Missing `gateSetAt` on a pre-fix state file (legacy state files predating this bug fix) is treated as infinitely old: no marker can satisfy the gate, and the user must provide a fresh approval. Mirrors the BUG-014 / AC9 precedent for missing `pausedAt` (RC-3)
+- [x] `record-approval.sh` continues to write fresh markers (mtime advances on each `UserPromptSubmit`) — verified by an extension to `record-approval.bats` covering `gateSetAt` interaction (RC-3)
+- [x] New bats fixture `guard-findings-edits.bats` covers the gate-on / gate-off / no-marker / stale-marker / fresh-marker / out-of-scope-path matrix (RC-1, RC-3)
+- [x] Extension to `guard-agent-prompts.bats` covers the `subagent_type: general-purpose` + embedded `name: finalizing-workflow` frontmatter case (deny) and the `subagent_type: general-purpose` + embedded `name: reviewing-requirements` case (allow) (RC-2)
+- [x] Extension to `guard-state-transitions.bats` covers `gateSetAt` interaction with existing `clear-gate` markers (regression coverage) (RC-3)
+- [x] CHORE-036 session is reproducible against the patched hooks: re-running the equivalent fork prompts denies; user-typed `approve findings-decision CHORE-036` and `merge CHORE-036` allow (RC-1, RC-2, RC-3)
+
+## Completion
+
+**Status:** `Pending`
+
+## Notes
+
+**Out of scope** (per issue #251):
+
+- Tightening the AC7 carve-out regexes (Gap 3 in the issue). Belt-and-suspenders only — closing Gap 2 makes the regexes redundant. Track separately if desired.
+- Stop-hook variants. Stop hooks fire after the fact and cannot deny a tool that already ran. PreToolUse is the correct primitive.
+- Subagent-tier hook inheritance audit. The proposed PreToolUse hooks fire on the parent and apply uniformly to forked subagents' tool calls.
+
+**Optional extension** (per issue #251): when `gate == findings-decision`, treat `reviewing-requirements` as confirmation-owning for the duration of the gate. This blocks the auto-fix re-fork path even if Gap 1's edit guard is somehow bypassed. Defer to implementation phase — closing the Edit guard alone (RC-1) is sufficient. Track separately if a follow-up bug after BUG-015 ships, the same way Gap 3's AC7 carve-out tightening is tracked separately above.
+
+**Related:**
+
+- BUG-014 — original confirmation-gate hook implementation. This bug is a follow-up.
+- PR #250 — CHORE-036 session where the bypasses were observed.
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/approval-marker-grammar.md` — canonical gate / marker grammar.
+- `plugins/lwndev-sdlc/skills/orchestrating-workflows/references/forked-steps.md` — orchestrator fork recipe documenting the `subagent_type: general-purpose` + embedded SKILL.md pattern.

--- a/scripts/__tests__/qa-bug-015-gates.test.ts
+++ b/scripts/__tests__/qa-bug-015-gates.test.ts
@@ -1,0 +1,316 @@
+// QA-BUG-015: Adversarial probes for the confirmation-gate hooks introduced
+// in BUG-015. These tests are independent of the bats fixtures the fix added —
+// they exercise the same hook scripts via vitest+execFileSync to give an
+// independent failure-mode signal under the QA persona.
+//
+// Plan reference: qa/test-plans/QA-plan-BUG-015.md
+// Hooks under test:
+//   plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh   (RC-1)
+//   plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh    (RC-2)
+//   plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh (RC-3)
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = process.cwd();
+const GUARD_FINDINGS_EDITS = join(
+  REPO_ROOT,
+  'plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh'
+);
+const GUARD_AGENT_PROMPTS = join(
+  REPO_ROOT,
+  'plugins/lwndev-sdlc/scripts/hooks/guard-agent-prompts.sh'
+);
+const WORKFLOW_STATE = join(
+  REPO_ROOT,
+  'plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts/workflow-state.sh'
+);
+
+type HookEnvelope = {
+  hookSpecificOutput?: { permissionDecision?: 'allow' | 'deny' | 'ask' };
+  systemMessage?: string;
+};
+
+function fireHook(
+  hookPath: string,
+  payload: unknown,
+  cwd: string
+): { stdout: string; status: number } {
+  const result = spawnSync('bash', [hookPath], {
+    encoding: 'utf-8',
+    cwd,
+    input: JSON.stringify(payload),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return { stdout: result.stdout ?? '', status: result.status ?? -1 };
+}
+
+function parseDecision(stdout: string): HookEnvelope | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as HookEnvelope;
+  } catch {
+    return null;
+  }
+}
+
+function setActiveWorkflow(repo: string, id: string): void {
+  mkdirSync(join(repo, '.sdlc/workflows'), { recursive: true });
+  writeFileSync(join(repo, '.sdlc/workflows/.active'), `${id}\n`);
+}
+
+function initWorkflowState(repo: string, id: string, type: 'feature' | 'chore' | 'bug'): void {
+  setActiveWorkflow(repo, id);
+  execFileSync('bash', [WORKFLOW_STATE, 'init', id, type], { cwd: repo, stdio: 'pipe' });
+}
+
+function setGate(repo: string, id: string, gateType: string): void {
+  execFileSync('bash', [WORKFLOW_STATE, 'set-gate', id, gateType], { cwd: repo, stdio: 'pipe' });
+}
+
+function clearGate(repo: string, id: string): void {
+  execFileSync('bash', [WORKFLOW_STATE, 'clear-gate', id], { cwd: repo, stdio: 'pipe' });
+}
+
+function writeMarker(repo: string, name: string, mtimeOffsetSeconds: number = 0): string {
+  const dir = join(repo, '.sdlc/approvals');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `.approval-${name}`);
+  writeFileSync(path, `timestamp: ${new Date().toISOString()}\n`);
+  if (mtimeOffsetSeconds !== 0) {
+    const seconds = Math.floor(Date.now() / 1000) + mtimeOffsetSeconds;
+    utimesSync(path, seconds, seconds);
+  }
+  return path;
+}
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'qa-bug-015-'));
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe('QA-BUG-015 RC-1: guard-findings-edits.sh denies Edit/Write/MultiEdit on gated requirements path', () => {
+  it.each([
+    ['Edit', 'requirements/bugs/BUG-100-foo.md'],
+    ['Write', 'requirements/features/FEAT-100-bar.md'],
+    ['MultiEdit', 'requirements/chores/CHORE-100-baz.md'],
+  ])('denies %s on %s with gate set and no marker', (toolName, filePath) => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: toolName, tool_input: { file_path: filePath } },
+      repo
+    );
+    expect(status).toBe(0);
+    const env = parseDecision(stdout);
+    expect(env, `expected JSON envelope on stdout, got: ${stdout}`).not.toBeNull();
+    expect(env?.hookSpecificOutput?.permissionDecision).toBe('deny');
+    expect(env?.systemMessage ?? '').toMatch(/findings-decision/);
+  });
+
+  it('allows Edit when gate is null (cleared)', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    clearGate(repo, 'BUG-100');
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'requirements/bugs/BUG-100-foo.md' } },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('allows Edit on out-of-scope path even when gate is set (no scope creep)', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'src/index.ts' } },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('denies Edit with stale marker (mtime predates gateSetAt)', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    writeMarker(repo, 'findings-decision-BUG-100', -3600);
+    setGate(repo, 'BUG-100', 'findings-decision');
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'requirements/bugs/BUG-100-foo.md' } },
+      repo
+    );
+    expect(status).toBe(0);
+    const env = parseDecision(stdout);
+    expect(env?.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('allows Edit with fresh marker (mtime >= gateSetAt)', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    // Write marker AFTER set-gate so its mtime exceeds gateSetAt
+    writeMarker(repo, 'findings-decision-BUG-100');
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'requirements/bugs/BUG-100-foo.md' } },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('denies Edit on legacy state file (no gateSetAt) after gate is set', () => {
+    // Simulate legacy state: init + set-gate but then strip gateSetAt to mimic
+    // a state file written by a pre-fix workflow-state.sh. The fix's
+    // set-gate writes gateSetAt; this test removes it post-hoc to assert the
+    // hook treats missing gateSetAt as infinitely old (BUG-014 / AC9 precedent).
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    writeMarker(repo, 'findings-decision-BUG-100');
+    const stateFile = join(repo, '.sdlc/workflows/BUG-100.json');
+    const beforeJson = JSON.parse(execFileSync('cat', [stateFile], { encoding: 'utf-8' }));
+    delete beforeJson.gateSetAt;
+    writeFileSync(stateFile, JSON.stringify(beforeJson, null, 2));
+    const { stdout } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'requirements/bugs/BUG-100-foo.md' } },
+      repo
+    );
+    const env = parseDecision(stdout);
+    expect(env?.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('allows Edit when no .active marker exists (no active workflow)', () => {
+    // No initWorkflowState, no .active file
+    const { stdout, status } = fireHook(
+      GUARD_FINDINGS_EDITS,
+      { tool_name: 'Edit', tool_input: { file_path: 'requirements/bugs/BUG-100-foo.md' } },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+});
+
+describe('QA-BUG-015 RC-2: guard-agent-prompts.sh extracts embedded SKILL.md name before subagent_type', () => {
+  it('denies general-purpose Agent fork with embedded name: finalizing-workflow and no merge marker', () => {
+    setActiveWorkflow(repo, 'BUG-100');
+    const prompt = '---\nname: finalizing-workflow\n---\nMerge the PR.';
+    const { stdout, status } = fireHook(
+      GUARD_AGENT_PROMPTS,
+      {
+        tool_name: 'Agent',
+        tool_input: { subagent_type: 'general-purpose', prompt },
+      },
+      repo
+    );
+    expect(status).toBe(0);
+    const env = parseDecision(stdout);
+    expect(env?.hookSpecificOutput?.permissionDecision, `expected deny, got: ${stdout}`).toBe(
+      'deny'
+    );
+    expect(env?.systemMessage ?? '').toMatch(/merge/i);
+  });
+
+  it('allows general-purpose Agent fork with embedded name: reviewing-requirements (no false positive)', () => {
+    setActiveWorkflow(repo, 'BUG-100');
+    const prompt = '---\nname: reviewing-requirements\n---\nValidate the document.';
+    const { stdout, status } = fireHook(
+      GUARD_AGENT_PROMPTS,
+      {
+        tool_name: 'Agent',
+        tool_input: { subagent_type: 'general-purpose', prompt },
+      },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('allows general-purpose Agent fork with embedded name: finalizing-workflow when fresh merge-approval marker exists', () => {
+    setActiveWorkflow(repo, 'BUG-100');
+    writeMarker(repo, 'merge-approval-BUG-100');
+    const prompt = '---\nname: finalizing-workflow\n---\nMerge the PR.';
+    const { stdout, status } = fireHook(
+      GUARD_AGENT_PROMPTS,
+      {
+        tool_name: 'Agent',
+        tool_input: { subagent_type: 'general-purpose', prompt },
+      },
+      repo
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('denies finalizing-workflow Agent fork (subagent_type direct) with no marker (regression — existing AC8)', () => {
+    setActiveWorkflow(repo, 'BUG-100');
+    const { stdout } = fireHook(
+      GUARD_AGENT_PROMPTS,
+      {
+        tool_name: 'Agent',
+        tool_input: { subagent_type: 'finalizing-workflow', prompt: 'Merge.' },
+      },
+      repo
+    );
+    const env = parseDecision(stdout);
+    expect(env?.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+});
+
+describe('QA-BUG-015 RC-3: workflow-state.sh records gateSetAt on set-gate / pause / clear-gate', () => {
+  function readState(id: string): Record<string, unknown> {
+    const path = join(repo, '.sdlc/workflows', `${id}.json`);
+    return JSON.parse(execFileSync('cat', [path], { encoding: 'utf-8' }));
+  }
+
+  it('writes gateSetAt as ISO-8601 on set-gate', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    const state = readState('BUG-100');
+    expect(state.gateSetAt).toBeTypeOf('string');
+    expect(state.gateSetAt as string).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it('resets gateSetAt to null on clear-gate', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    clearGate(repo, 'BUG-100');
+    const state = readState('BUG-100');
+    expect(state.gateSetAt).toBeNull();
+  });
+
+  it('resets gateSetAt to null on pause (auto-clears gate)', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    setGate(repo, 'BUG-100', 'findings-decision');
+    execFileSync('bash', [WORKFLOW_STATE, 'pause', 'BUG-100', 'review-findings'], {
+      cwd: repo,
+      stdio: 'pipe',
+    });
+    const state = readState('BUG-100');
+    expect(state.gate).toBeNull();
+    expect(state.gateSetAt).toBeNull();
+  });
+
+  it('init writes gate=null and gateSetAt=null', () => {
+    initWorkflowState(repo, 'BUG-100', 'bug');
+    const state = readState('BUG-100');
+    expect(state.gate).toBeNull();
+    // gateSetAt may be absent (legacy parity) or null on init; both are valid
+    if ('gateSetAt' in state) {
+      expect(state.gateSetAt).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two structural confirmation-gate bypasses observed in the CHORE-036 / PR #250 session.

Closes #251

### RC-1 — Hook B matcher scope is too narrow

New hook `plugins/lwndev-sdlc/scripts/hooks/guard-findings-edits.sh` wired in `hooks.json` for `PreToolUse` matcher `Edit|Write|MultiEdit`. While `gate == findings-decision` is set on the active workflow, an Edit/Write/MultiEdit against `requirements/(features|chores|bugs)/.+\.md` is denied without a fresh `.approval-findings-decision-<active-ID>` marker (mtime ≥ `gateSetAt`). Out-of-scope paths and gate-cleared workflows pass through.

### RC-2 — Hook C trusts `subagent_type` over the embedded prompt

`guard-agent-prompts.sh` now extracts the embedded SKILL.md `name:` frontmatter FIRST. When the embedded name belongs to the confirmation-owning set (today: `finalizing-workflow`), it takes precedence over `tool_input.subagent_type`, closing the `Agent(subagent_type: general-purpose, prompt: <finalizing-workflow SKILL.md verbatim>)` bypass. Non-confirmation-owning embedded names (e.g. `reviewing-requirements`) still allow — no false positives on legitimate general-purpose forks.

### RC-3 — `set-gate` does not record `gateSetAt`

`workflow-state.sh` now writes a `gateSetAt: <ISO-8601>` timestamp on `set-gate`, resets it to null on `clear-gate` / `cmd_pause` / `cmd_resume` / `cmd_advance`, and migrates legacy state files defensively. Missing `gateSetAt` on a pre-fix state file is treated as "infinitely old" — mirrors BUG-014 / AC9 `pausedAt` semantics. The new findings-decision Edit guard reads `gateSetAt` to detect stale markers from earlier gate cycles.

## Test plan

- [x] New `guard-findings-edits.bats` (30 fixtures): gate-on/off/no-marker/stale/fresh/out-of-scope-path matrix; per-tool parity (Edit/Write/MultiEdit); legacy state file (no gateSetAt) → deny; corrupt JSON / malformed `.active` / traversal path safety; full set-gate → deny → approve → allow → clear-gate cycle; auto-mode reproduction.
- [x] `guard-agent-prompts.bats` extended (7 new fixtures): `subagent_type: general-purpose` + embedded `name: finalizing-workflow` → deny; same shape + `name: reviewing-requirements` → allow; existing AC8 path still denies; plugin-prefixed embedded names recognized.
- [x] `guard-state-transitions.bats` extended: `gateSetAt` interaction with `clear-gate` regression.
- [x] `record-approval.bats` extended: `mv -f` advances marker mtime on each UserPromptSubmit (gateSetAt freshness invariant).
- [x] `npm test` — 1531 / 1531 vitest tests pass.
- [x] `bats plugins/lwndev-sdlc/scripts/tests/hooks/*.bats` — 150 / 150 bats fixtures pass.
- [x] `verify-build-health.sh` exits 0 (lint, format:check, test, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)