### PR TITLE
fix(BUG-022): fix re-QA false positive by cross-checking workflow state in detect-re-qa-mode.sh

### DIFF
--- a/plugins/lwndev-sdlc/skills/executing-qa/SKILL.md
+++ b/plugins/lwndev-sdlc/skills/executing-qa/SKILL.md
@@ -44,7 +44,7 @@ Script paths below are relative to `${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/sc
 1. Accept a requirement ID; record the active marker; record the diff baseline:
    - `Write .sdlc/qa/.executing-active`
    - `bash "$SCRIPTS/qa-baseline.sh" init <ID>`
-2. Mode auto-detect (FEAT-032 FR-3): `bash "$SCRIPTS/detect-re-qa-mode.sh" <ID>`. JSON `{mode, files}`. `mode=re-qa` -> Step 5 re-QA branch (skip persona-loaded test-writing); `mode=initial` -> initial-run path.
+2. Mode auto-detect (FEAT-032 FR-3, BUG-022): `bash "$SCRIPTS/detect-re-qa-mode.sh" <ID>`. JSON `{mode, files}`. Detection cross-checks `workflow-state.sh get-qa-state <ID>` (`qaFixAttempts`/`qaLastVerdict`) — fresh IDs resolve `initial` regardless of committed `qa-*` files or marker state. `mode=re-qa` -> Step 5 re-QA branch (skip persona-loaded test-writing); `mode=initial` -> initial-run path.
 3. Capability discovery + drift check:
    - `bash "$SCRIPTS/capability-discovery.sh" <consumer-root> <ID>`
    - `bash "$SCRIPTS/capability-report-diff.sh" "<plan-file>" "<fresh-json>"`
@@ -101,7 +101,7 @@ The following MUST always be emitted even when they resemble narration:
 At skill start:
 
 1. Write `.sdlc/qa/.executing-active` (empty file). Signals the stop hook that `executing-qa` is active.
-2. `bash "${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/scripts/qa-baseline.sh" init <ID>` writes `.sdlc/qa/.executing-qa-baseline-<ID>` with the current HEAD SHA. The FR-10 stop-hook diff guard reads this baseline to scope the diff check.
+2. `bash "${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/scripts/qa-baseline.sh" init <ID>` writes `.sdlc/qa/.executing-qa-baseline-<ID>` with the current HEAD SHA. The FR-10 stop-hook diff guard reads this baseline to scope the diff check. This marker is NOT a prior-run signal for `detect-re-qa-mode.sh` — detection uses `workflow-state.sh get-qa-state <ID>` instead (BUG-022).
 
 The stop hook removes both files on success; in orchestrated workflows the orchestrator cleans up after return. To clear the baseline manually: `bash "$SCRIPTS/qa-baseline.sh" clear <ID>`.
 
@@ -125,7 +125,7 @@ If no ID is provided, ask for one.
 
 2. **Initialize state**:
    - `Write .sdlc/qa/.executing-active` (empty file).
-   - `bash ${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/scripts/qa-baseline.sh init <ID>` — writes the diff-guard baseline. Idempotent on re-QA: rewrites the marker to the current HEAD (the marker's existence — not its SHA — is what `detect-re-qa-mode.sh` keys on).
+   - `bash ${CLAUDE_PLUGIN_ROOT}/skills/executing-qa/scripts/qa-baseline.sh init <ID>` — writes the diff-guard baseline. Used by the FR-10 stop-hook diff guard to scope the diff check; NOT used by `detect-re-qa-mode.sh` for re-QA detection (BUG-022).
 
 3. **Mode auto-detect (FEAT-032 FR-3)**:
    ```

--- a/plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh
+++ b/plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# detect-re-qa-mode.sh (FEAT-032 FR-3) — Auto-detect whether executing-qa is
-# running in initial-run mode or re-QA mode for the given requirement ID.
+# detect-re-qa-mode.sh (FEAT-032 FR-3, BUG-022) — Auto-detect whether
+# executing-qa is running in initial-run mode or re-QA mode for the given
+# requirement ID.
 #
 # Re-QA mode is entered when BOTH of these hold:
-#   (a) The qa-baseline marker file `.sdlc/qa/.executing-qa-baseline-<ID>` exists
-#       (set by qa-baseline.sh init from a prior executing-qa run for the same ID).
+#   (a) The requirement ID has a genuine prior QA run recorded in workflow state:
+#       qaFixAttempts >= 1 OR qaLastVerdict is non-null.
+#       State is read via workflow-state.sh get-qa-state <ID> (co-located in
+#       the orchestrating-workflows skill). Fail-safe: any read failure
+#       (missing state file, non-zero exit, malformed JSON) yields
+#       priorRun=false -> mode=initial. Never fails to re-qa on unavailable state.
 #   (b) At least one committed QA test file matches the v1 glob set:
 #         tests/unit/qa-*.test.ts
 #         tests/unit/qa-*.test.js
@@ -22,15 +27,16 @@ set -euo pipefail
 #   {"mode":"initial","files":[]}
 #
 # Exit codes:
-#   0 always (mode is on stdout; missing marker / missing files are not errors)
+#   0 always (mode is on stdout; state-read failures are not errors)
 #   2 missing/invalid args
 #
 # Notes:
-#   * The script does NOT touch the marker file — it only reads.
+#   * The script does NOT touch any marker or state file — it only reads.
 #   * The script uses `git ls-files` so untracked qa-*.test.ts files do NOT
 #     trigger re-QA mode (mirroring the FR-9 finalize safety-net contract).
-#   * No new marker is introduced for re-QA — re-detection on every entry uses
-#     the existing baseline marker as the "this ID has run before" signal.
+#   * The baseline marker (.sdlc/qa/.executing-qa-baseline-<ID>) is NOT used
+#     for re-QA detection. It is written by qa-baseline.sh init (always) for
+#     the FR-10 stop-hook diff guard; its presence is not a prior-run signal.
 
 usage() {
   echo "Usage: detect-re-qa-mode.sh <ID>" >&2
@@ -49,7 +55,9 @@ if [[ -z "$ID" ]]; then
   exit 2
 fi
 
-MARKER_PATH=".sdlc/qa/.executing-qa-baseline-${ID}"
+# Resolve workflow-state.sh relative to this script's directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WFSTATE="${SCRIPT_DIR}/../../orchestrating-workflows/scripts/workflow-state.sh"
 
 # Glob set per FR-3 v1. Forward-compat .py/.go globs intentionally absent in
 # v1 per Edge Case 17.
@@ -72,8 +80,24 @@ if [[ -n "$FILES" ]]; then
   FILES_JSON="$(printf '%s\n' "$FILES" | jq -R -s 'split("\n") | map(select(length > 0))')"
 fi
 
+# Determine whether a genuine prior QA run exists for this ID.
+# Cross-check workflow state (BUG-022 fix): a prior run requires qaFixAttempts>=1
+# OR qaLastVerdict non-null. Fail-safe to priorRun=false on any read error so
+# initial runs are never misclassified as re-qa when state is unavailable.
+PRIOR_RUN=false
+if [[ -x "$WFSTATE" ]] || [[ -f "$WFSTATE" ]]; then
+  _state_json="$(bash "$WFSTATE" get-qa-state "$ID" 2>/dev/null || true)"
+  if [[ -n "$_state_json" ]]; then
+    _fix_attempts="$(printf '%s' "$_state_json" | jq -r '.qaFixAttempts // 0' 2>/dev/null || true)"
+    _last_verdict="$(printf '%s' "$_state_json" | jq -r '.qaLastVerdict // "null"' 2>/dev/null || true)"
+    if [[ "${_fix_attempts:-0}" -ge 1 ]] || [[ "$_last_verdict" != "null" && -n "$_last_verdict" ]]; then
+      PRIOR_RUN=true
+    fi
+  fi
+fi
+
 MODE="initial"
-if [[ -f "$MARKER_PATH" ]] && [[ "$(printf '%s' "$FILES_JSON" | jq 'length')" -gt 0 ]]; then
+if [[ "$PRIOR_RUN" == "true" ]] && [[ "$(printf '%s' "$FILES_JSON" | jq 'length')" -gt 0 ]]; then
   MODE="re-qa"
 fi
 

--- a/plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh
+++ b/plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh
@@ -31,7 +31,11 @@ set -euo pipefail
 #   2 missing/invalid args
 #
 # Notes:
-#   * The script does NOT touch any marker or state file — it only reads.
+#   * The script does NOT directly write any marker or state file. Note that
+#     the get-qa-state read can transitively rewrite the state file: it routes
+#     through workflow-state.sh validate_state_file -> _migrate_state_file,
+#     which migrates a pre-FEAT-032 schema (missing qaFixAttempts/qaLastVerdict/
+#     etc.) in place. That migration is idempotent and benign.
 #   * The script uses `git ls-files` so untracked qa-*.test.ts files do NOT
 #     trigger re-QA mode (mirroring the FR-9 finalize safety-net contract).
 #   * The baseline marker (.sdlc/qa/.executing-qa-baseline-<ID>) is NOT used

--- a/qa/test-plans/QA-plan-BUG-022.md
+++ b/qa/test-plans/QA-plan-BUG-022.md
@@ -1,0 +1,66 @@
+---
+id: BUG-022
+version: 2
+timestamp: 2026-05-29T13:42:01Z
+persona: qa
+---
+
+## User Summary
+
+`executing-qa` must not falsely enter re-QA mode on the first QA run for a
+fresh requirement ID. Before the fix, when committed `qa-*` test files existed
+on the branch, re-QA detection returned `mode=re-qa` on an initial run — the
+skill then skipped test authoring and ran unrelated prior-workflow tests,
+yielding a misleading PASS. After the fix, an initial run for an ID with no
+prior QA history resolves to `mode=initial` regardless of committed `qa-*`
+files, while a genuine prior QA run for the same ID still resolves to `re-qa`.
+The system under test is the shell detection contract (`detect-re-qa-mode.sh`
+and its interaction with `qa-baseline.sh init`, committed `qa-*` files, and
+the per-ID workflow state), exercised via Bats.
+
+## Capability Report
+
+- Mode: test-framework
+- Framework: vitest
+- Package manager: npm
+- Test command: npm test
+- Language: typescript
+
+> Note: capability discovery reports the repo's primary framework (vitest), but
+> the code under QA is shell. Deterministic scenarios are expressed as Bats
+> tests (`npx bats`, graded on exit code); they are tagged `mode: test-framework`.
+> Tooling-absence and environment scenarios are `exploratory`.
+
+## Scenarios (by dimension)
+
+### Inputs
+- [P0] Fresh ID (no prior QA history) with committed `qa-*.test.ts` present on the branch and the baseline marker freshly written by the current run -> resolves to `mode=initial` | mode: test-framework | expected: Bats asserts JSON `.mode == "initial"`, exit 0
+- [P0] Genuine prior run for the same ID (prior fix attempt or recorded verdict) with committed `qa-*` files present -> resolves to `mode=re-qa` | mode: test-framework | expected: Bats asserts `.mode == "re-qa"` and `.files` non-empty, exit 0
+- [P1] Committed `qa-*` files belong to an unrelated ID while the ID under test is fresh -> `mode=initial` (per-ID isolation, not branch-wide) | mode: test-framework | expected: Bats asserts `.mode == "initial"`
+- [P1] Missing or empty ID argument -> usage error, exit 2 (existing contract preserved) | mode: test-framework | expected: Bats asserts non-zero exit and stderr usage line
+- [P1] ID containing shell-special characters or a non-existent ID -> no crash; mode derived from state lookup | mode: test-framework | expected: Bats asserts exit 0 and valid JSON
+- [P2] Baseline marker present but empty or malformed (non-SHA) contents -> decision keys on per-ID state, not marker contents | mode: test-framework | expected: Bats asserts `.mode == "initial"` for a fresh ID
+
+### State transitions
+- [P0] Same ID across two sequential runs: first run records QA history, second run flips `initial -> re-qa` given committed `qa-*` files | mode: test-framework | expected: Bats drives two invocations and asserts the mode transition
+- [P1] Prior run recorded a verdict but zero fix attempts (e.g. an initial ERROR/EXPLORATORY-ONLY) -> subsequent run for the ID treated as a genuine prior run | mode: test-framework | expected: Bats asserts `.mode == "re-qa"` when only the verdict signal is set
+- [P1] No workflow state file exists for the ID (manual `/executing-qa` outside an orchestrated workflow) -> deterministic, documented fallback (no false re-qa) | mode: test-framework | expected: Bats asserts a defined mode and exit 0 with no state file present
+
+### Environment
+- [P1] Invoked outside a git repository / `git` unavailable -> graceful degradation, no unhandled error | mode: test-framework | expected: Bats asserts exit 0 and `.files == []`
+- [P2] Invoked from a subdirectory rather than the repo root -> `.sdlc/qa` and `tests/` path assumptions resolve correctly or fail cleanly | mode: exploratory | expected: manual run from a nested cwd; observe path resolution
+- [P2] `jq` absent or a different version on PATH -> detection does not hard-crash with an opaque error | mode: exploratory | expected: manual run with `jq` shadowed; observe error clarity
+
+### Dependency failure
+- [P1] `workflow-state.sh get-qa-state` (or equivalent state read) returns non-zero or malformed JSON -> detection fails safe to `initial`, not `re-qa` | mode: test-framework | expected: Bats stubs a failing state read and asserts `.mode == "initial"`
+- [P2] State file present but missing `qaFixAttempts` / `qaLastVerdict` fields (pre-FEAT-032 schema) -> defaults (0 / null) applied -> `initial` for a fresh ID | mode: test-framework | expected: Bats seeds a legacy-shaped state file and asserts `.mode == "initial"`
+
+### Cross-cutting (a11y, i18n, concurrency, permissions)
+- [P1] Idempotency: two back-to-back detect invocations for the same ID yield the same mode and never mutate the marker (read-only contract) | mode: test-framework | expected: Bats asserts identical output across runs and marker SHA unchanged
+- [P2] Two different IDs on the same branch with committed `qa-*` files: a fresh ID stays `initial` while a prior-run ID resolves `re-qa` in the same tree | mode: test-framework | expected: Bats seeds divergent per-ID state and asserts each mode independently
+- [P2] `qa-baseline.sh init` ordering: with `init` called before detect (current SKILL.md step order), a fresh ID still resolves `initial` -> the fix holds regardless of call-site ordering | mode: test-framework | expected: Bats reproduces the step-1-then-step-2 sequence and asserts `initial`
+
+## Non-applicable dimensions
+
+- a11y: the system under test is a CLI/shell detection script with no user interface surface; no accessibility behavior to probe.
+- i18n: detection emits machine-readable JSON keyed on fixed ASCII tokens (`initial`/`re-qa`); no localized or user-facing natural-language output.

--- a/qa/test-results/QA-results-BUG-022.md
+++ b/qa/test-results/QA-results-BUG-022.md
@@ -1,0 +1,101 @@
+---
+id: BUG-022
+version: 2
+timestamp: 2026-05-29T16:42:37Z
+verdict: PASS
+persona: qa
+---
+
+## Summary
+
+Verdict PASS: passed=9, failed=0, errored=0.
+
+## Capability Report
+
+```json
+{
+  "id": "BUG-022",
+  "timestamp": "2026-05-29T16:34:09Z",
+  "mode": "test-framework",
+  "framework": "vitest",
+  "packageManager": "npm",
+  "testCommand": "npm test",
+  "language": "typescript",
+  "notes": []
+}
+```
+
+## Execution Results
+
+- Total: 9
+- Passed: 9
+- Failed: 0
+- Errored: 0
+- Exit code: 0
+
+## Scenarios Run
+
+All scenarios run as Bats against the repo working-tree `detect-re-qa-mode.sh`
+(the BUG-022 fix copy), graded on `npx bats` exit code. 9 passed, 0 failed, 0 errored.
+
+### Inputs
+- [P1] Shell-injection ID `FEAT-$(touch PWNED)` does not execute; stdout is valid JSON; mode=initial | mode: test-framework | expected: exit 0, no command executed, `.mode == "initial"` — PASS
+- [P1] Non-existent ID with no state -> exit 0, valid JSON, mode=initial | mode: test-framework | expected: exit 0, valid JSON — PASS
+- [P2] Empty/malformed baseline marker ignored; decision keys on per-ID state -> mode=initial | mode: test-framework | expected: `.mode == "initial"` — PASS
+
+### State transitions
+- [P0] Same ID across two sequential runs flips `initial` -> `re-qa` only after a genuine prior run is recorded | mode: test-framework | expected: run1 initial, run2 re-qa — PASS
+
+### Environment
+- [P1] Invoked outside any git repository -> exit 0, `.files == []`, mode=initial (graceful degradation) | mode: test-framework | expected: exit 0, files empty, initial — PASS
+
+### Dependency failure
+- [P1] Malformed state JSON (`get-qa-state` unparseable) fails safe to `initial`, never `re-qa` | mode: test-framework | expected: `.mode == "initial"` — PASS
+- [P2] Legacy pre-FEAT-032 state file lacking `qaFixAttempts`/`qaLastVerdict` -> defaults -> `initial` for a fresh ID | mode: test-framework | expected: `.mode == "initial"` — PASS
+
+### Cross-cutting
+- [P1] Idempotency: back-to-back invocations yield identical stdout and never mutate the baseline marker | mode: test-framework | expected: identical output, marker hash unchanged — PASS
+- [P2] Two IDs on one branch sharing a committed `qa-*` file: fresh stays `initial`, prior-run resolves `re-qa` | mode: test-framework | expected: per-ID isolation — PASS
+
+Non-applicable: a11y (no UI surface) and i18n (machine-readable JSON keyed on fixed ASCII tokens) are not relevant to this shell detection contract, per the test plan.
+
+## Findings
+
+No defects found. All 9 adversarial scenarios across the five dimensions passed
+against the repo working-tree `detect-re-qa-mode.sh` (the BUG-022 state-cross-check
+fix). The fix correctly resolves `mode=initial` on a fresh ID even with committed
+`qa-*` files plus a present baseline marker, resolves `re-qa` only when workflow
+state records a genuine prior run (`qaFixAttempts >= 1` OR `qaLastVerdict` set),
+and fails safe to `initial` on missing/malformed/legacy state.
+
+- Inputs: no defect — injection ID inert, malformed marker ignored, decision keys on state.
+- State transitions: no defect — `initial -> re-qa` flip occurs only after a recorded prior run.
+- Environment: no defect — graceful degradation outside a git repo (`files: []`, exit 0).
+- Dependency failure: no defect — malformed and legacy state both fail safe to `initial`.
+- Cross-cutting: no defect — idempotent, marker untouched, per-ID isolation holds.
+
+Coverage note: `qa-verify-coverage.sh` reports COVERAGE-ADEQUATE across all five
+dimensions. Reconciliation `coverage-gap` entries are a text-match artifact of the
+heuristic reconciler (AC checkboxes are not literal scenario lines); the acceptance
+criteria are exercised by the scenarios above and the permanent regression at
+`tests/bats/skills/executing-qa/re-qa-mode.bats`.
+
+Note: `run-framework.sh` parses vitest output only and is blind to Bats; these
+deterministic shell scenarios were run directly via `npx bats` and graded on exit
+code, per the QA plan's capability note.
+
+## Reconciliation Delta
+
+### Coverage beyond requirements
+- Scenario "Ran 9 passing tests, 0 failing tests, 0 errored tests." — not mentioned in spec
+
+### Coverage gaps
+- AC-1 "[x] An initial QA run for an ID with `qaFixAttempts == 0 && qaLastVerdict == null` resolves to `mode=initial` even when " — no corresponding scenario in plan
+- AC-2 "[x] Re-QA mode is NOT entered solely because unrelated prior-workflow `qa-*` test files are committed on the branch (RC-" — no corresponding scenario in plan
+- AC-3 "[x] A genuine prior QA run for the same ID (`qaFixAttempts >= 1` or `qaLastVerdict` set) still resolves to `mode=re-qa` " — no corresponding scenario in plan
+- AC-4 "[x] Regression test covers both the false-positive case (fresh ID + committed `qa-*` files -> initial) and the true-posi" — no corresponding scenario in plan
+
+### Summary
+- coverage-surplus: 1
+- coverage-gap: 4
+

--- a/requirements/bugs/BUG-022-qa-re-mode-false.md
+++ b/requirements/bugs/BUG-022-qa-re-mode-false.md
@@ -1,0 +1,113 @@
+# Bug: QA re-mode false positive on initial run
+
+## Bug ID
+
+`BUG-022`
+
+## GitHub Issue
+
+[#302](https://github.com/lwndev/lwndev-marketplace/issues/302)
+
+## Category
+
+`logic-error`
+
+## Severity
+
+`high`
+
+## Description
+
+`executing-qa` falsely resolves `mode=re-qa` on the first QA run for a fresh
+requirement ID whenever the branch carries committed `qa-*` test files. The
+skill then skips test-writing and runs unrelated prior-workflow QA tests,
+emitting a misleading PASS that never exercises the feature under QA.
+
+## Steps to Reproduce
+
+Precondition: the current branch carries at least one committed file matching
+`tests/unit/qa-*.test.ts`, `tests/unit/qa-*.test.js`, or `tests/bats/qa/qa-*.bats`.
+(On this repo `main` is normally clean of these because the FR-9 finalize gate
+blocks merges that retain `qa-*` files — see Notes. The precondition holds on a
+feature branch mid-workflow, or on any branch where the gate was bypassed.)
+
+1. Start a new workflow with a fresh ID (e.g. FEAT-NNN / BUG-NNN). Workflow
+   state shows `qaFixAttempts: 0`, `qaLastVerdict: null` — no prior QA run for
+   this ID.
+2. Drive the chain to the Execute QA step.
+3. Quick Start step 1 runs `qa-baseline.sh init <ID>`, then step 2 runs
+   `detect-re-qa-mode.sh <ID>`.
+4. Observe: `{"mode":"re-qa","files":[<unrelated prior-workflow qa-*.test.ts>]}`.
+5. Expected: `{"mode":"initial","files":[...]}` — `qaFixAttempts` is 0 and no
+   prior QA run for this ID exists.
+
+## Expected Behavior
+
+On an initial QA run for an ID with no prior QA history
+(`qaFixAttempts == 0 && qaLastVerdict == null`), detection resolves to
+`mode=initial` regardless of committed `qa-*` test files on the branch. The
+skill writes fresh adversarial tests for the feature under QA. Re-QA mode is
+entered only when a genuine prior QA run for the same ID has occurred.
+
+## Actual Behavior
+
+Detection returns `mode=re-qa` on the first run. `executing-qa` skips the
+test-writing phase, runs unrelated prior-workflow `qa-*` tests as the
+fix-grade signal, and emits a PASS verdict with no adversarial coverage of the
+feature under QA. The orchestrator advances and the workflow finalizes — the
+change merges to main without QA having exercised it.
+
+## Root Cause(s)
+
+1. `detect-re-qa-mode.sh` infers "a prior QA run exists for this ID" from the
+   conjunction of (a) baseline-marker presence and (b) any committed `qa-*`
+   test file on the branch (`plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh:76`).
+   Neither condition is a reliable per-ID prior-run signal, and the
+   authoritative state (`qaFixAttempts` / `qaLastVerdict`, available via
+   `workflow-state.sh get-qa-state <ID>`) is never consulted:
+   - The baseline marker is written unconditionally by `qa-baseline.sh init`
+     (`plugins/lwndev-sdlc/skills/executing-qa/scripts/qa-baseline.sh:33-36`,
+     `git rev-parse HEAD > "$MARKER_PATH"`, no existence check), and the
+     executing-qa Quick Start runs that `init` (step 1) *before*
+     `detect-re-qa-mode.sh` (step 2). So the marker the detector reads always
+     belongs to the current run, never a prior one.
+   - The committed-file condition matches `qa-*` tests from *any* prior
+     workflow, not just QA runs for the ID under test.
+
+   Both halves of the conjunction therefore hold on every initial run whenever
+   the branch carries committed `qa-*` files, and the detector reports `re-qa`.
+
+## Affected Files
+
+- `plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh` — re-QA decision (conjunction at line 76); primary fix surface.
+- `plugins/lwndev-sdlc/skills/executing-qa/scripts/qa-baseline.sh` — unconditional `init` marker write (lines 33-36); mechanism context.
+- `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` — Quick Start step 1/step 2 ordering and the "State File Management" section; update in lockstep with any chosen fix.
+- `tests/bats/skills/executing-qa/` — regression coverage for the detection contract.
+
+## Acceptance Criteria
+
+- [x] An initial QA run for an ID with `qaFixAttempts == 0 && qaLastVerdict == null` resolves to `mode=initial` even when committed `qa-*` test files exist on the branch and the baseline marker is present (RC-1)
+- [x] Re-QA mode is NOT entered solely because unrelated prior-workflow `qa-*` test files are committed on the branch (RC-1)
+- [x] A genuine prior QA run for the same ID (`qaFixAttempts >= 1` or `qaLastVerdict` set) still resolves to `mode=re-qa` when committed `qa-*` files exist — the real re-QA path does not regress (RC-1)
+- [x] Regression test covers both the false-positive case (fresh ID + committed `qa-*` files -> initial) and the true-positive case (prior run + committed `qa-*` files -> re-qa) (RC-1)
+
+## Completion
+
+**Status:** `Pending`
+
+## Notes
+
+- Detection runs in a workflow's executing-qa step from the **cached** plugin
+  copy, not this repo's working tree. A repo-side fix is not live for an
+  in-flight workflow until the plugin is re-released and the cache updated.
+- Tension with FR-9: the finalize preflight blocks merges that retain tracked
+  `qa-*` files, so `main` is normally clean of them. The repro precondition
+  (committed `qa-*` files present) is reached on feature branches mid-workflow
+  or when the gate is bypassed — not on a clean `main`.
+- Interim operator workaround (issue #302): on initial runs, if
+  `detect-re-qa-mode.sh` reports `re-qa` while `qaFixAttempts`/`qaLastVerdict`
+  are zero/null, `qa-baseline.sh clear <ID>` -> re-detect -> `qa-baseline.sh init <ID>`.
+- Issue #302 proposes three fix options (re-order Quick Start; idempotent
+  `init`; cross-check state inside the detector). The fix surface is deferred
+  to the implementation step; the acceptance criteria above are behavioral and
+  satisfiable by any of them.

--- a/requirements/bugs/BUG-022-qa-re-mode-false.md
+++ b/requirements/bugs/BUG-022-qa-re-mode-false.md
@@ -93,7 +93,9 @@ change merges to main without QA having exercised it.
 
 ## Completion
 
-**Status:** `Pending`
+**Status:** `Completed`
+**Date:** 2026-05-29
+**PR:** [#306](https://github.com/lwndev/lwndev-marketplace/pull/306)
 
 ## Notes
 

--- a/requirements/bugs/BUG-022-qa-re-mode-false.md
+++ b/requirements/bugs/BUG-022-qa-re-mode-false.md
@@ -80,9 +80,14 @@ change merges to main without QA having exercised it.
 ## Affected Files
 
 - `plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh` — re-QA decision (conjunction at line 76); primary fix surface.
-- `plugins/lwndev-sdlc/skills/executing-qa/scripts/qa-baseline.sh` — unconditional `init` marker write (lines 33-36); mechanism context.
+- `plugins/lwndev-sdlc/skills/executing-qa/scripts/qa-baseline.sh` (planned but not modified)
 - `plugins/lwndev-sdlc/skills/executing-qa/SKILL.md` — Quick Start step 1/step 2 ordering and the "State File Management" section; update in lockstep with any chosen fix.
-- `tests/bats/skills/executing-qa/` — regression coverage for the detection contract.
+- `tests/bats/skills/executing-qa/` (planned but not modified)
+- `qa/test-plans/QA-plan-BUG-022.md`
+- `qa/test-results/QA-results-BUG-022.md`
+- `requirements/bugs/BUG-022-qa-re-mode-false.md`
+- `tests/bats/skills/executing-qa/re-qa-mode.bats`
+- `tests/bats/skills/executing-qa/re-qa-mode.qa.bats`
 
 ## Acceptance Criteria
 
@@ -93,9 +98,11 @@ change merges to main without QA having exercised it.
 
 ## Completion
 
-**Status:** `Completed`
-**Date:** 2026-05-29
-**PR:** [#306](https://github.com/lwndev/lwndev-marketplace/pull/306)
+**Status:** `Complete`
+
+**Completed:** 2026-05-29
+
+**Pull Request:** [#306](https://github.com/lwndev/lwndev-marketplace/pull/306)
 
 ## Notes
 

--- a/tests/bats/qa/qa-detect-re-qa-mode.bats
+++ b/tests/bats/qa/qa-detect-re-qa-mode.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# QA-BUG-022 — adversarial QA for the detect-re-qa-mode.sh state-cross-check fix.
+# SUT: plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh (repo
+# working-tree copy carrying the BUG-022 fix). Ephemeral QA tests; consumed by
+# addressing-qa-findings, adopted into a *.qa.bats sibling on PASS.
+#
+# Coverage focuses on adversarial dimensions NOT already exercised by the
+# permanent regression at tests/bats/skills/executing-qa/re-qa-mode.bats:
+#   Inputs (injection / weird ID, malformed marker)
+#   State transitions (sequential initial -> re-qa flip)
+#   Dependency failure (malformed state JSON, legacy schema)
+#   Environment (outside a git repo)
+#   Cross-cutting (idempotency, two-ID isolation on one branch)
+
+setup() {
+  # tests/bats/qa is THREE levels below repo root.
+  SCRIPT_DIR="$(cd "${BATS_TEST_DIRNAME}/../../../plugins/lwndev-sdlc/skills/executing-qa/scripts" && pwd)"
+  SCRIPT="${SCRIPT_DIR}/detect-re-qa-mode.sh"
+  WFSTATE="$(cd "${BATS_TEST_DIRNAME}/../../../plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts" && pwd)/workflow-state.sh"
+  TMPDIR_TEST="$(mktemp -d)"
+  cd "$TMPDIR_TEST"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "init"
+}
+
+teardown() {
+  if [[ -n "${TMPDIR_TEST:-}" && -d "$TMPDIR_TEST" ]]; then
+    rm -rf "$TMPDIR_TEST"
+  fi
+}
+
+_wf_init() { bash "$WFSTATE" init "$1" bug >/dev/null; }
+
+_wf_set_prior_run() {
+  _wf_init "$1"
+  bash "$WFSTATE" inc-qa-fix-attempts "$1" >/dev/null
+  bash "$WFSTATE" set-qa-verdict "$1" ISSUES-FOUND >/dev/null
+}
+
+_commit_qa_file() {
+  mkdir -p tests/unit
+  echo "// qa test" > "tests/unit/$1"
+  git add "tests/unit/$1"
+  git commit -q -m "qa: add $1"
+}
+
+# --- Inputs: adversarial ID strings -----------------------------------------
+
+@test "QA-BUG-022: shell-injection ID does not execute; valid JSON, mode=initial" {
+  _commit_qa_file qa-foo.test.ts
+  # An ID that would run a command if interpolated unquoted into a shell call.
+  run bash "$SCRIPT" 'FEAT-$(touch PWNED)'
+  [ "$status" -eq 0 ]
+  [ ! -e PWNED ]                              # injection must NOT have fired
+  echo "$output" | jq -e . >/dev/null         # stdout is valid JSON
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+@test "QA-BUG-022: non-existent ID with no state -> exit 0, valid JSON, initial" {
+  _commit_qa_file qa-foo.test.ts
+  run bash "$SCRIPT" BUG-99999
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+@test "QA-BUG-022: empty/malformed baseline marker keys on state, not marker -> initial" {
+  _wf_init FEAT-300          # fresh: qaFixAttempts=0, qaLastVerdict=null
+  mkdir -p .sdlc/qa
+  printf 'not-a-sha\n\n###\n' > .sdlc/qa/.executing-qa-baseline-FEAT-300
+  _commit_qa_file qa-foo.test.ts
+  run bash "$SCRIPT" FEAT-300
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+# --- State transitions: sequential flip -------------------------------------
+
+@test "QA-BUG-022: same ID flips initial -> re-qa once a prior run is recorded" {
+  _wf_init FEAT-301
+  _commit_qa_file qa-foo.test.ts
+
+  run bash "$SCRIPT" FEAT-301           # first run: no prior QA history
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+
+  bash "$WFSTATE" set-qa-verdict FEAT-301 ISSUES-FOUND >/dev/null
+  bash "$WFSTATE" inc-qa-fix-attempts FEAT-301 >/dev/null
+
+  run bash "$SCRIPT" FEAT-301           # second run: prior history now present
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "re-qa"' >/dev/null
+  echo "$output" | jq -e '.files | length >= 1' >/dev/null
+}
+
+# --- Dependency failure: state read fails safe ------------------------------
+
+@test "QA-BUG-022: malformed state JSON fails safe to initial (not re-qa)" {
+  mkdir -p .sdlc/workflows
+  printf '{ this is not valid json ::: ' > .sdlc/workflows/FEAT-302.json
+  _commit_qa_file qa-foo.test.ts
+  run bash "$SCRIPT" FEAT-302
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+@test "QA-BUG-022: legacy state file lacking qaFixAttempts/qaLastVerdict -> initial" {
+  mkdir -p .sdlc/workflows
+  # Pre-FEAT-032 shaped state: no qaFixAttempts / qaLastVerdict fields.
+  printf '{"id":"FEAT-303","type":"bug","currentStep":5,"status":"in-progress","steps":[]}\n' \
+    > .sdlc/workflows/FEAT-303.json
+  _commit_qa_file qa-foo.test.ts
+  run bash "$SCRIPT" FEAT-303
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+# --- Environment: no git repo -----------------------------------------------
+
+@test "QA-BUG-022: outside a git repo -> exit 0, files=[], mode=initial" {
+  NONGIT="$(mktemp -d)"
+  cd "$NONGIT"
+  run bash "$SCRIPT" FEAT-304
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+  echo "$output" | jq -e '.files | length == 0' >/dev/null
+  rm -rf "$NONGIT"
+}
+
+# --- Cross-cutting: idempotency + isolation ---------------------------------
+
+@test "QA-BUG-022: back-to-back invocations are idempotent; marker untouched" {
+  _wf_set_prior_run FEAT-305
+  mkdir -p .sdlc/qa
+  echo "deadbeef" > .sdlc/qa/.executing-qa-baseline-FEAT-305
+  _commit_qa_file qa-foo.test.ts
+  marker_before="$(md5 -q .sdlc/qa/.executing-qa-baseline-FEAT-305 2>/dev/null || md5sum .sdlc/qa/.executing-qa-baseline-FEAT-305 | cut -d' ' -f1)"
+
+  run bash "$SCRIPT" FEAT-305
+  [ "$status" -eq 0 ]
+  out1="$output"
+  run bash "$SCRIPT" FEAT-305
+  [ "$status" -eq 0 ]
+  out2="$output"
+
+  [ "$out1" = "$out2" ]                        # identical stdout
+  echo "$out1" | jq -e '.mode == "re-qa"' >/dev/null
+  marker_after="$(md5 -q .sdlc/qa/.executing-qa-baseline-FEAT-305 2>/dev/null || md5sum .sdlc/qa/.executing-qa-baseline-FEAT-305 | cut -d' ' -f1)"
+  [ "$marker_before" = "$marker_after" ]       # detect never writes the marker
+}
+
+@test "QA-BUG-022: two IDs on one branch — fresh stays initial, prior resolves re-qa" {
+  _wf_init FEAT-306                    # fresh ID
+  _wf_set_prior_run FEAT-307          # genuine prior run
+  _commit_qa_file qa-shared.test.ts   # one committed qa-* file, branch-wide
+
+  run bash "$SCRIPT" FEAT-306
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+
+  run bash "$SCRIPT" FEAT-307
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "re-qa"' >/dev/null
+}

--- a/tests/bats/skills/executing-qa/re-qa-mode.bats
+++ b/tests/bats/skills/executing-qa/re-qa-mode.bats
@@ -1,10 +1,12 @@
 #!/usr/bin/env bats
 # FEAT-032 FR-3 — re-QA mode auto-detection (detect-re-qa-mode.sh) + FR-13
 # negative invariant (re-QA never deletes QA files).
+# BUG-022 — state-cross-check: detect uses qaFixAttempts/qaLastVerdict, not marker.
 
 setup() {
   SCRIPT_DIR="$(cd "${BATS_TEST_DIRNAME}/../../../../plugins/lwndev-sdlc/skills/executing-qa/scripts" && pwd)"
   SCRIPT="${SCRIPT_DIR}/detect-re-qa-mode.sh"
+  WFSTATE="$(cd "${BATS_TEST_DIRNAME}/../../../../plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts" && pwd)/workflow-state.sh"
   TMPDIR_TEST="$(mktemp -d)"
   cd "$TMPDIR_TEST"
   git init -q
@@ -17,6 +19,20 @@ teardown() {
   if [[ -n "${TMPDIR_TEST:-}" && -d "$TMPDIR_TEST" ]]; then
     rm -rf "$TMPDIR_TEST"
   fi
+}
+
+# Helper: init workflow state for an ID so get-qa-state succeeds.
+_wf_init() {
+  local id="$1"
+  bash "$WFSTATE" init "$id" bug >/dev/null
+}
+
+# Helper: set genuine prior-run state (qaFixAttempts=1, qaLastVerdict=ISSUES-FOUND).
+_wf_set_prior_run() {
+  local id="$1"
+  _wf_init "$id"
+  bash "$WFSTATE" inc-qa-fix-attempts "$id" >/dev/null
+  bash "$WFSTATE" set-qa-verdict "$id" ISSUES-FOUND >/dev/null
 }
 
 # --- arg validation ---------------------------------------------------------
@@ -58,7 +74,9 @@ teardown() {
   echo "$output" | jq -e '.mode == "initial"' >/dev/null
 }
 
-@test "marker + tracked QA .test.ts -> mode=re-qa" {
+# BUG-022: genuine prior run (qaFixAttempts>=1) + committed QA .test.ts -> re-qa
+@test "prior run state + tracked QA .test.ts -> mode=re-qa" {
+  _wf_set_prior_run FEAT-100
   mkdir -p .sdlc/qa tests/unit
   echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-100
   echo "// qa test" > tests/unit/qa-foo.test.ts
@@ -71,7 +89,9 @@ teardown() {
   echo "$output" | jq -e '.files[0] == "tests/unit/qa-foo.test.ts"' >/dev/null
 }
 
-@test "marker + tracked QA .test.js -> mode=re-qa" {
+# BUG-022: genuine prior run + committed QA .test.js -> re-qa
+@test "prior run state + tracked QA .test.js -> mode=re-qa" {
+  _wf_set_prior_run FEAT-100
   mkdir -p .sdlc/qa tests/unit
   echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-100
   echo "// qa test" > tests/unit/qa-foo.test.js
@@ -83,7 +103,9 @@ teardown() {
   echo "$output" | jq -e '.files[0] == "tests/unit/qa-foo.test.js"' >/dev/null
 }
 
-@test "marker + tracked QA .bats under tests/bats/qa/ -> mode=re-qa" {
+# BUG-022: genuine prior run + committed QA .bats -> re-qa
+@test "prior run state + tracked QA .bats under tests/bats/qa/ -> mode=re-qa" {
+  _wf_set_prior_run FEAT-100
   mkdir -p .sdlc/qa tests/bats/qa
   echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-100
   echo "@test 'a' { :; }" > tests/bats/qa/qa-foo.bats
@@ -118,7 +140,9 @@ teardown() {
   echo "$output" | jq -e '.mode == "initial"' >/dev/null
 }
 
-@test "marker + multiple tracked QA files -> mode=re-qa with all files in array" {
+# BUG-022: genuine prior run + multiple tracked QA files -> re-qa with all files
+@test "prior run state + multiple tracked QA files -> mode=re-qa with all files in array" {
+  _wf_set_prior_run FEAT-100
   mkdir -p .sdlc/qa tests/unit tests/bats/qa
   echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-100
   echo "// a" > tests/unit/qa-a.test.ts
@@ -132,9 +156,74 @@ teardown() {
   echo "$output" | jq -e '.files | length == 3' >/dev/null
 }
 
+# --- BUG-022 regression: false-positive case --------------------------------
+
+# Fresh ID (qaFixAttempts==0, qaLastVerdict==null) + committed qa-* files +
+# marker present -> must resolve mode=initial (not re-qa).
+@test "BUG-022: fresh ID + committed qa-* files + marker -> mode=initial (not re-qa)" {
+  # Init state with zero attempts, null verdict (fresh workflow).
+  _wf_init FEAT-200
+  mkdir -p .sdlc/qa tests/unit
+  # Marker present (as it would be after qa-baseline.sh init runs before detect).
+  echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-200
+  # Committed qa-* files from an unrelated prior workflow.
+  echo "// leftover from prior workflow" > tests/unit/qa-leftover.test.ts
+  git add tests/unit/qa-leftover.test.ts
+  git commit -q -m "qa(FEAT-111): leftover from prior workflow"
+  run bash "$SCRIPT" FEAT-200
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
+# BUG-022 regression: true-positive case.
+# Prior run (qaFixAttempts>=1 OR qaLastVerdict set) + committed qa-* files
+# -> mode=re-qa (genuine re-QA path does not regress).
+@test "BUG-022: prior run (qaFixAttempts=1) + committed qa-* files -> mode=re-qa" {
+  _wf_set_prior_run FEAT-201
+  mkdir -p .sdlc/qa tests/unit
+  echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-201
+  echo "// qa test from prior run" > tests/unit/qa-fix1.test.ts
+  git add tests/unit/qa-fix1.test.ts
+  git commit -q -m "qa(FEAT-201): add fix1 tests"
+  run bash "$SCRIPT" FEAT-201
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "re-qa"' >/dev/null
+}
+
+# BUG-022 regression: qaLastVerdict set (PASS), qaFixAttempts=0
+# -> still re-qa because qaLastVerdict is non-null.
+@test "BUG-022: qaLastVerdict=PASS, qaFixAttempts=0 + committed qa-* files -> mode=re-qa" {
+  _wf_init FEAT-202
+  bash "$WFSTATE" set-qa-verdict FEAT-202 PASS >/dev/null
+  mkdir -p .sdlc/qa tests/unit
+  echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-202
+  echo "// qa test" > tests/unit/qa-pass.test.ts
+  git add tests/unit/qa-pass.test.ts
+  git commit -q -m "qa(FEAT-202): add pass tests"
+  run bash "$SCRIPT" FEAT-202
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "re-qa"' >/dev/null
+}
+
+# BUG-022 regression: fail-safe path — no state file at all -> mode=initial.
+# Simulates running detect in an environment where workflow-state.sh can't find
+# the state file (fresh branch with no .sdlc/workflows/).
+@test "BUG-022: no state file (fail-safe) + committed qa-* files + marker -> mode=initial" {
+  mkdir -p .sdlc/qa tests/unit
+  echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-203
+  echo "// qa test" > tests/unit/qa-failsafe.test.ts
+  git add tests/unit/qa-failsafe.test.ts
+  git commit -q -m "qa(FEAT-203): add tests"
+  # No workflow state initialized for FEAT-203 — get-qa-state will fail.
+  run bash "$SCRIPT" FEAT-203
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.mode == "initial"' >/dev/null
+}
+
 # --- FR-13 negative invariant: detect doesn't delete files ------------------
 
 @test "FR-13: detect-re-qa-mode.sh never deletes QA files" {
+  _wf_set_prior_run FEAT-100
   mkdir -p .sdlc/qa tests/unit
   echo "abc123" > .sdlc/qa/.executing-qa-baseline-FEAT-100
   echo "// qa test" > tests/unit/qa-foo.test.ts

--- a/tests/bats/skills/executing-qa/re-qa-mode.qa.bats
+++ b/tests/bats/skills/executing-qa/re-qa-mode.qa.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 # QA-BUG-022 — adversarial QA for the detect-re-qa-mode.sh state-cross-check fix.
-# SUT: plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh (repo
-# working-tree copy carrying the BUG-022 fix). Ephemeral QA tests; consumed by
-# addressing-qa-findings, adopted into a *.qa.bats sibling on PASS.
+# SUT: plugins/lwndev-sdlc/skills/executing-qa/scripts/detect-re-qa-mode.sh.
+# Adopted from the ephemeral QA run (qa-detect-re-qa-mode.bats) into this
+# permanent *.qa.bats sibling next to the peer regression re-qa-mode.bats.
 #
 # Coverage focuses on adversarial dimensions NOT already exercised by the
 # permanent regression at tests/bats/skills/executing-qa/re-qa-mode.bats:
@@ -13,10 +13,10 @@
 #   Cross-cutting (idempotency, two-ID isolation on one branch)
 
 setup() {
-  # tests/bats/qa is THREE levels below repo root.
-  SCRIPT_DIR="$(cd "${BATS_TEST_DIRNAME}/../../../plugins/lwndev-sdlc/skills/executing-qa/scripts" && pwd)"
+  # tests/bats/skills/executing-qa is FOUR levels below repo root.
+  SCRIPT_DIR="$(cd "${BATS_TEST_DIRNAME}/../../../../plugins/lwndev-sdlc/skills/executing-qa/scripts" && pwd)"
   SCRIPT="${SCRIPT_DIR}/detect-re-qa-mode.sh"
-  WFSTATE="$(cd "${BATS_TEST_DIRNAME}/../../../plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts" && pwd)/workflow-state.sh"
+  WFSTATE="$(cd "${BATS_TEST_DIRNAME}/../../../../plugins/lwndev-sdlc/skills/orchestrating-workflows/scripts" && pwd)/workflow-state.sh"
   TMPDIR_TEST="$(mktemp -d)"
   cd "$TMPDIR_TEST"
   git init -q


### PR DESCRIPTION
## Summary

fix BUG-022: fix re-QA false positive by cross-checking workflow state in detect-re-qa-mode.sh

Closes #302

## Test plan

- [ ] Tests updated or added as appropriate
- [ ] `npm run validate` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)