### PR TITLE
release(lwndev-sdlc): v1.27.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.27.0"
+      "version": "1.27.1"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.27.1] - 2026-05-31
+
+Maintenance release: three bug fixes to the SDLC workflow skills plus a dependency bump. No new features or breaking changes.
+
+### Bug Fixes
+
+- **BUG-021:** Remove the unsupported `--project` flag from `az repos pr show`/`update` in `managing-source-control`. Azure DevOps PR view/update operations no longer fail on backends where the flag is rejected ([#305](https://github.com/lwndev/lwndev-marketplace/pull/305)).
+- **BUG-022:** Cross-check workflow state in `detect-re-qa-mode.sh` so the QA loop reliably distinguishes a re-QA run from a first run, including transitive state migration ([#306](https://github.com/lwndev/lwndev-marketplace/pull/306)).
+- **BUG-020:** Harden orchestrator pause-step documentation and the merge-approval gate; correct `set-gate` help text and `cmd_advance` line citations ([#297](https://github.com/lwndev/lwndev-marketplace/pull/297)).
+
+### Chores
+
+- **deps:** Bump `brace-expansion` to 5.0.6 to clear an npm audit advisory.
+
+[1.27.1]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.27.0...lwndev-sdlc@1.27.1
+
 ## [1.27.0] - 2026-05-18
 
 ### Features

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.27.0 | **Released:** 2026-05-18
+**Version:** 1.27.1 | **Released:** 2026-05-31
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
## Release: lwndev-sdlc v1.27.1

Maintenance release: three bug fixes to the SDLC workflow skills plus a dependency bump. No new features or breaking changes.

### Bug Fixes
- **BUG-021:** Remove the unsupported `--project` flag from `az repos pr show`/`update` in `managing-source-control`. Azure DevOps PR view/update operations no longer fail on backends where the flag is rejected (#305).
- **BUG-022:** Cross-check workflow state in `detect-re-qa-mode.sh` so the QA loop reliably distinguishes a re-QA run from a first run, including transitive state migration (#306).
- **BUG-020:** Harden orchestrator pause-step documentation and the merge-approval gate; correct `set-gate` help text and `cmd_advance` line citations (#297).

### Chores
- **deps:** Bump `brace-expansion` to 5.0.6 to clear an npm audit advisory.

### Release checklist
- [x] Version bumped consistently (`plugin.json`, `marketplace.json`, `README.md`) → 1.27.1
- [x] Changelog refined to user-facing summary
- [x] build-health gate passed (15/15 skills validated)
- [ ] After merge: re-invoke `/releasing-plugins` Phase 2 to tag `lwndev-sdlc@1.27.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
