### PR TITLE
release(lwndev-sdlc): v1.27.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.27.1"
+      "version": "1.27.2"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.27.2] - 2026-05-31
+
+Maintenance release: one bug fix to the QA-adoption routing in the SDLC workflow skills. No new features or breaking changes.
+
+### Bug Fixes
+
+- **BUG-023:** Route an initial-run QA `PASS` through `addressing-qa-findings` (adopt phase) whenever committed `qa-*` test files are git-visible, instead of advancing straight to `finalizing-workflow`. Initial-PASS QA tests are now promoted into their `*.qa.*` regression siblings rather than being left on the branch to trip the FR-9 finalize gate. Updates `qa-dispatch.sh`/`detect-phase` routing to the OR-form contract and aligns the contract comments ([#308](https://github.com/lwndev/lwndev-marketplace/pull/308)).
+
+[1.27.2]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.27.1...lwndev-sdlc@1.27.2
+
 ## [1.27.1] - 2026-05-31
 
 Maintenance release: three bug fixes to the SDLC workflow skills plus a dependency bump. No new features or breaking changes.

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.27.1 | **Released:** 2026-05-31
+**Version:** 1.27.2 | **Released:** 2026-05-31
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 

--- a/tests/bats/skills/executing-qa/stop-hook.bats
+++ b/tests/bats/skills/executing-qa/stop-hook.bats
@@ -19,6 +19,15 @@ setup() {
   # Create a throwaway workspace.
   TMPDIR_TEST="$(mktemp -d)"
 
+  # Per-test QA ID. The capability JSON the stop hook reads lives at a fixed
+  # global path (/tmp/qa-capability-<ID>.json) keyed only by ID, so every test
+  # sharing one literal ID would race on that one file under `bats --jobs`
+  # (a concurrent `jq -n > …` truncation reads back empty → framework lost →
+  # diff guard wrongly skipped). Derive a process-unique ID from the unique
+  # TMPDIR_TEST (sanitised to the [A-Za-z0-9_-]+ charset the hook greps for in
+  # QA-results-<ID>.md filenames) so each test owns its own capability file.
+  QA_ID="FEAT-030-$(basename "$TMPDIR_TEST" | tr -cd 'A-Za-z0-9')"
+
   # Initialise a git repo (identity required for commits).
   git -C "$TMPDIR_TEST" init -q
   git -C "$TMPDIR_TEST" config user.email "test@bats"
@@ -38,10 +47,10 @@ setup() {
   git -C "$TMPDIR_TEST" commit -q -m "initial"
 
   # Write a valid v2 QA results artifact.
-  write_results_artifact "$TMPDIR_TEST" "FEAT-030" "PASS"
+  write_results_artifact "$TMPDIR_TEST" "$QA_ID" "PASS"
 
   # Write a vitest capability JSON.
-  write_capability_json "$TMPDIR_TEST" "FEAT-030" "vitest"
+  write_capability_json "$TMPDIR_TEST" "$QA_ID" "vitest"
 
   # Write the ACTIVE file so the hook is not short-circuited.
   touch "$TMPDIR_TEST/.sdlc/qa/.executing-active"
@@ -53,6 +62,12 @@ setup() {
 teardown() {
   if [[ -n "${TMPDIR_TEST:-}" && -d "$TMPDIR_TEST" ]]; then
     rm -rf "$TMPDIR_TEST"
+  fi
+  # The capability JSON lives at the fixed global /tmp path; remove this test's
+  # own copy so it neither leaks nor lingers for an unrelated run. Safe under
+  # parallelism because QA_ID is process-unique.
+  if [[ -n "${QA_ID:-}" ]]; then
+    rm -f "/tmp/qa-capability-${QA_ID}.json"
   fi
 }
 
@@ -141,12 +156,12 @@ write_baseline() {
 
 @test "FR-10: pure addition inside test root is allowed" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Add a new spec file inside __tests__.
   printf 'test("qa", () => {})\n' > "$TMPDIR_TEST/__tests__/qa-inputs.spec.ts"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 0 ]
   # Active file should be removed.
   [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-active" ]
@@ -158,12 +173,12 @@ write_baseline() {
 
 @test "FR-10: modification of existing test file inside test root is allowed" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Modify existing spec.
   printf '// updated\ntest("qa", () => {})\n' > "$TMPDIR_TEST/__tests__/foo.spec.ts"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 0 ]
 }
 
@@ -173,14 +188,14 @@ write_baseline() {
 
 @test "FR-10: edit outside test root is blocked with verbatim error" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Commit a production file modification after baseline.
   printf 'export const x = 2;\n' > "$TMPDIR_TEST/src/index.ts"
   git -C "$TMPDIR_TEST" add "src/index.ts"
   git -C "$TMPDIR_TEST" commit -q -m "qa: accidentally edit production file"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 2 ]
   [[ "$output" == *"Stop hook: executing-qa modified production files outside the framework test root"* ]]
   [[ "$output" == *"src/index.ts"* ]]
@@ -193,17 +208,17 @@ write_baseline() {
 
 @test "FR-10: QA result and plan artifacts are always allowed" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Modify the QA results artifact itself.
   # (already written by write_results_artifact; just touch it)
-  printf '# extra line\n' >> "$TMPDIR_TEST/qa/test-results/QA-results-FEAT-030.md"
+  printf '# extra line\n' >> "$TMPDIR_TEST/qa/test-results/QA-results-${QA_ID}.md"
 
   # Also add a test plan artifact.
   mkdir -p "$TMPDIR_TEST/qa/test-plans"
-  printf '# test plan\n' > "$TMPDIR_TEST/qa/test-plans/QA-plan-FEAT-030.md"
+  printf '# test plan\n' > "$TMPDIR_TEST/qa/test-plans/QA-plan-${QA_ID}.md"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 0 ]
 }
 
@@ -218,7 +233,7 @@ write_baseline() {
   printf 'export const x = 99;\n' > "$TMPDIR_TEST/src/index.ts"
 
   # Baseline captures HEAD (the original commit, before this dirty change).
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # No further changes to src/index.ts after baseline — git diff HEAD..HEAD is empty
   # for committed files, but src/index.ts is only staged/modified; since diff is
@@ -231,7 +246,7 @@ write_baseline() {
   # history. So the diff output for committed changes (tracked by git diff HEAD)
   # is empty for src/index.ts because only the index was changed before baseline.
   # We verify hook passes (no false positive).
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 0 ]
 }
 
@@ -243,10 +258,10 @@ write_baseline() {
   cd "$TMPDIR_TEST"
   # Deliberately do NOT write the baseline marker.
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 2 ]
   [[ "$output" == *"missing baseline marker"* ]]
-  [[ "$output" == *".executing-qa-baseline-FEAT-030"* ]]
+  [[ "$output" == *".executing-qa-baseline-${QA_ID}"* ]]
   [[ "$output" == *"Re-run executing-qa from the start"* ]]
 }
 
@@ -256,13 +271,13 @@ write_baseline() {
 
 @test "FR-10: rename from inside test root to outside is blocked" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Commit a rename after baseline: move __tests__/foo.spec.ts -> src/foo.spec.ts
   git -C "$TMPDIR_TEST" mv "__tests__/foo.spec.ts" "src/foo.spec.ts"
   git -C "$TMPDIR_TEST" commit -q -m "rename spec out of test root"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 2 ]
   [[ "$output" == *"Stop hook: executing-qa modified production files"* ]]
   [[ "$output" == *"src/foo.spec.ts"* ]]
@@ -274,25 +289,25 @@ write_baseline() {
 
 @test "FR-10: cleanup on success removes both active file and baseline marker" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 0 ]
   [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-active" ]
-  [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-qa-baseline-FEAT-030" ]
+  [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-qa-baseline-${QA_ID}" ]
 }
 
 @test "FR-10: cleanup on failure removes both active file and baseline marker" {
   cd "$TMPDIR_TEST"
-  write_baseline "$TMPDIR_TEST" "FEAT-030"
+  write_baseline "$TMPDIR_TEST" "$QA_ID"
 
   # Cause a failure by committing a production file modification after baseline.
   printf 'export const x = 2;\n' > "$TMPDIR_TEST/src/index.ts"
   git -C "$TMPDIR_TEST" add "src/index.ts"
   git -C "$TMPDIR_TEST" commit -q -m "qa: accidentally edit production file"
 
-  run bash "$STOP_HOOK" <<< "$(build_hook_input "FEAT-030")"
+  run bash "$STOP_HOOK" <<< "$(build_hook_input "$QA_ID")"
   [ "$status" -eq 2 ]
   [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-active" ]
-  [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-qa-baseline-FEAT-030" ]
+  [ ! -f "$TMPDIR_TEST/.sdlc/qa/.executing-qa-baseline-${QA_ID}" ]
 }


### PR DESCRIPTION
Patch release of **lwndev-sdlc**: `1.27.1` → `1.27.2`.

## Changelog

Maintenance release: one bug fix to the QA-adoption routing in the SDLC workflow skills. No new features or breaking changes.

### Bug Fixes

- **BUG-023:** Route an initial-run QA `PASS` through `addressing-qa-findings` (adopt phase) whenever committed `qa-*` test files are git-visible, instead of advancing straight to `finalizing-workflow`. Initial-PASS QA tests are now promoted into their `*.qa.*` regression siblings rather than being left on the branch to trip the FR-9 finalize gate. Updates `qa-dispatch.sh`/`detect-phase` routing to the OR-form contract and aligns the contract comments (#308).

## Release checklist

- [x] Version bumped consistently in `plugin.json`, `marketplace.json`, `README.md`
- [x] Changelog entry added (dated 2026-05-31)
- [x] Build-health gate passed (15/15 skills validated)
- [x] Release-commit review clean

After merge, re-invoke `/releasing-plugins` to tag the release (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)