### PR TITLE
release(lwndev-sdlc): v1.27.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.27.2"
+      "version": "1.27.3"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.27.3] - 2026-06-01
+
+Maintenance release: relocates the `finalizing-workflow` write-surface guard to a reliable enforcement point. No new features or breaking changes.
+
+### Bug Fixes
+
+- **BUG-024:** Move the finalize write-surface guard out of the dead, forked Stop hook (which never ran) into a pre-merge in-script check (`arm-baseline.sh` + `check-write-surface.sh`), with the baseline stored in the git dir. The guard now actually blocks merges that touch the protected write surface ([#310](https://github.com/lwndev/lwndev-marketplace/pull/310)).
+
+[1.27.3]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.27.2...lwndev-sdlc@1.27.3
+
 ## [1.27.2] - 2026-05-31
 
 Maintenance release: one bug fix to the QA-adoption routing in the SDLC workflow skills. No new features or breaking changes.

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.27.2 | **Released:** 2026-05-31
+**Version:** 1.27.3 | **Released:** 2026-06-01
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
Maintenance release for **lwndev-sdlc**: `1.27.2 → 1.27.3`. No new features or breaking changes.

## Bug Fixes

- **BUG-024:** Move the finalize write-surface guard out of the dead, forked Stop hook (which never ran) into a pre-merge in-script check (`arm-baseline.sh` + `check-write-surface.sh`), with the baseline stored in the git dir. The guard now actually blocks merges that touch the protected write surface (#310).

## Release contents

- Bumped version across `plugin.json`, `marketplace.json`, and `README.md`
- Refined `CHANGELOG.md` entry (dropped QA/test noise commits)
- Build-health gate passed: lint, format:check, test, build/validate all green

After merge, run `npm run release:tag -- --plugin lwndev-sdlc` (Phase 2) to push the `lwndev-sdlc@1.27.3` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)