### PR TITLE
release(lwndev-sdlc): v1.27.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lwndev-sdlc",
       "source": "./plugins/lwndev-sdlc",
       "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
-      "version": "1.27.3"
+      "version": "1.27.4"
     }
   ]
 }

--- a/plugins/lwndev-sdlc/.claude-plugin/plugin.json
+++ b/plugins/lwndev-sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lwndev-sdlc",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "SDLC workflow skills for documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities",
   "author": {
     "name": "lwndev"

--- a/plugins/lwndev-sdlc/CHANGELOG.md
+++ b/plugins/lwndev-sdlc/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.27.4] - 2026-06-02
+
+Maintenance release: one bug fix to QA-test adoption plus a dev-dependency bump. No new features or breaking changes.
+
+### Bug Fixes
+
+- **BUG-025:** `adopt-qa-test.sh` now tolerates a QA test whose SUT resolves to multiple peer tests — it picks the lexicographically-first peer and adopts into its `*.qa.*` sibling instead of failing the adopt, while preserving the multi-peer reason for the ambiguous single-SUT case ([#312](https://github.com/lwndev/lwndev-marketplace/pull/312)).
+
+### Chores
+
+- **deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#313](https://github.com/lwndev/lwndev-marketplace/pull/313)).
+
+[1.27.4]: https://github.com/lwndev/lwndev-marketplace/compare/lwndev-sdlc@1.27.3...lwndev-sdlc@1.27.4
+
 ## [1.27.3] - 2026-06-01
 
 Maintenance release: relocates the `finalizing-workflow` write-surface guard to a reliable enforcement point. No new features or breaking changes.

--- a/plugins/lwndev-sdlc/README.md
+++ b/plugins/lwndev-sdlc/README.md
@@ -1,6 +1,6 @@
 # lwndev-sdlc
 
-**Version:** 1.27.3 | **Released:** 2026-06-01
+**Version:** 1.27.4 | **Released:** 2026-06-02
 
 SDLC workflow skills for Claude Code — documenting, planning, and executing features, chores, and bug fixes with QA validation capabilities.
 


### PR DESCRIPTION
Maintenance release for `lwndev-sdlc`: one bug fix to QA-test adoption plus a dev-dependency bump. No new features or breaking changes.

## Bug Fixes
- **BUG-025:** `adopt-qa-test.sh` now tolerates a QA test whose SUT resolves to multiple peer tests — it picks the lexicographically-first peer and adopts into its `*.qa.*` sibling instead of failing the adopt, while preserving the multi-peer reason for the ambiguous single-SUT case (#312).

## Chores
- **deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update (#313).

## Release metadata
- Version: 1.27.3 → 1.27.4 (consistent across `plugin.json`, `marketplace.json`, `README.md`)
- Build-health gate: passed
- Changelog: `plugins/lwndev-sdlc/CHANGELOG.md`

After merge, tag via Phase 2: `/releasing-plugins` (or `npm run release:tag -- --plugin lwndev-sdlc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)