### PR TITLE
docs(agents): record triage labels as created

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -16,7 +16,7 @@ Edit the right-hand column to match whatever vocabulary you actually use.
 
 ## Repo state
 
-`wontfix` already exists in this repo (GitHub's default label set). The other four do not — create them on first use:
+All five labels exist. `wontfix` ships with GitHub's default set; the other four were created on 2026-08-01 with the commands below, kept for reference:
 
 ```bash
 gh label create needs-triage    --color "d876e3" --description "Maintainer needs to evaluate this issue"
@@ -24,5 +24,7 @@ gh label create needs-info      --color "fbca04" --description "Waiting on repor
 gh label create ready-for-agent --color "0e8a16" --description "Fully specified, ready for an AFK agent"
 gh label create ready-for-human --color "1d76db" --description "Requires human implementation"
 ```
+
+Re-running `gh label create` on an existing label fails. Use `gh label edit <name>` to change a colour or description.
 
 These are distinct from the repo's existing workflow labels (`bug`, `enhancement`, `qa-loop-lifecycle`, `wayfinder:*`) — no collision.


### PR DESCRIPTION
## What

`docs/agents/triage-labels.md` claimed the four non-default triage labels did not exist. They do now — created on 2026-08-01 with the commands already recorded in that file.

## Why

`/triage` reads this file to decide which label strings to apply. Leaving a stale "these do not exist" claim there is a small but real trap.

## Change

- "Repo state" now records that all five canonical labels exist.
- Commands kept for reference, with a note that `gh label create` fails on an existing label and `gh label edit` is the way to change colour or description.

Labels created on the repo (outside this diff):

| label | colour |
|---|---|
| `needs-triage` | `d876e3` |
| `needs-info` | `fbca04` |
| `ready-for-agent` | `0e8a16` |
| `ready-for-human` | `1d76db` |

`wontfix` already shipped with GitHub's default set.

## Verification

Docs-only. Full suite green in the worktree: 63 test files, 1707 tests, `npm audit` clean, `npm run validate` 15/15 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)